### PR TITLE
fix(clipmenu): update xsel usage

### DIFF
--- a/clipmenu
+++ b/clipmenu
@@ -34,7 +34,7 @@ chosen_line=$(
 
 for selection in clipboard primary; do
     if type -p xsel >/dev/null 2>&1; then
-        xsel --"$selection" < "${selections[$chosen_line]}"
+        xsel -i --"$selection" < "${selections[$chosen_line]}"
     else
         xclip -sel "$selection" < "${selections[$chosen_line]}"
     fi


### PR DESCRIPTION
Changes:
* `xsel` now requires an input flag `(-a|-f|-i)` see [`XSEL(1x)`](http://manned.org/xsel/843cf846)