### PR TITLE
Take over the clipboard to persist it after the owner quits

### DIFF
--- a/clipmenud
+++ b/clipmenud
@@ -9,8 +9,10 @@ while sleep "${CLIPMENUD_SLEEP:-0.5}"; do
     for selection in clipboard primary; do
         if type -p xsel >/dev/null 2>&1; then
             data=$(xsel --"$selection"; printf x)
+            xsel --"$selection" | xsel -i --"$selection"
         else
             data=$(xclip -o -sel "$selection"; printf x)
+            xclip -o -sel "$selection" | xclip -i -sel "$selection"
         fi
 
         # We add and remove the x so that trailing newlines are not stripped.

--- a/clipmenud
+++ b/clipmenud
@@ -9,10 +9,15 @@ while sleep "${CLIPMENUD_SLEEP:-0.5}"; do
     for selection in clipboard primary; do
         if type -p xsel >/dev/null 2>&1; then
             data=$(xsel --"$selection"; printf x)
-            xsel --"$selection" | xsel -i --"$selection"
+            # Take ownership of clipboard, in case the original application is
+            # unable to serve the clipboard request
+            # Exclude primary from this behavior in order not to mess with the owner
+            [[ $selection != "primary" ]] && xsel --"$selection" | xsel -i --"$selection"
         else
             data=$(xclip -o -sel "$selection"; printf x)
-            xclip -o -sel "$selection" | xclip -i -sel "$selection"
+            # See above
+            [[ $selection != "primary" ]] && xclip -o -sel "$selection" | \
+                xclip -i -sel "$selection"
         fi
 
         # We add and remove the x so that trailing newlines are not stripped.


### PR DESCRIPTION
I often copy things from Neovim, after which I either quit or suspend (^z) to paste in another instance. If I quit, the clipboard contents are lost, if I suspend, pasting blocks because Neovim is suspended and the destination application can't communicate with it. This PR fixes it and should work with any other application.