### PR TITLE
remove duplicate entries whilst keeping time order

### DIFF
--- a/clipmenud
+++ b/clipmenud
@@ -52,6 +52,7 @@ while sleep "${CLIPMENUD_SLEEP:-0.5}"; do
         last_data[$selection]=$data
         last_filename[$selection]=$filename
 
+        rm -f "$cache_dir"/*-$md5
         printf '%s' "$data" > "$filename"
     done
 done


### PR DESCRIPTION
i found that clipmenud creates duplicate entries when i selct them again and again in clipmenu.
to avoid this, i added a simple line (sledge hammer method): `rm -f "$cache_dir"/*-$md5`
thus, reselected exisiting entries are pushed to the top of the menu, and old ones deleted.