### PR TITLE
Perform an insertion after the selection when --insert given

### DIFF
--- a/clipmenu
+++ b/clipmenu
@@ -35,6 +35,14 @@ for (( i=${#files[@]}-1; i>=0; i-- )); do
     selections[$first_line]=$file
 done
 
+# provide the option insert, to perform an insertion an the end
+# remove it when it is given, because the rest of the options will
+# be passed to dmenu
+if [[ $1 == '--insert' ]]; then
+    perform_insert=1
+    shift
+fi
+
 # It's okay to hardcode `-l 8` here as a sensible default without checking
 # whether `-l` is also in "$@", because the way that dmenu works allows a later
 # argument to override an earlier one. That is, if the user passes in `-l`, our
@@ -50,3 +58,8 @@ for selection in clipboard primary; do
         xclip -sel "$selection" < "${selections[$chosen_line]}"
     fi
 done
+
+# perform the insertion
+if [[ $perform_insert == 1 ]]; then
+    xdotool key shift+Insert
+fi


### PR DESCRIPTION
Added an option that enables the tool to insert the selected clipboard entry directly on the focused input.

So far tested this with i3 with a keybinding:

    bindsym $mod+shift+b exec --no-startup-id clipmenu --insert
