### PR TITLE
Hide the contents of clipboard from the systemd service logs

### DIFF
--- a/clipmenud
+++ b/clipmenud
@@ -2,6 +2,7 @@
 
 : "${CM_ONESHOT=0}"
 : "${CM_OWN_CLIPBOARD=1}"
+: "${CM_PRIVACY=1}"
 : "${CM_DEBUG=0}"
 : "${TMPDIR=/tmp}"
 
@@ -61,6 +62,7 @@ Environment variables:
 
 - $CM_ONESHOT: run once immediately, do not loop (default: 0)
 - $CM_DEBUG: turn on debugging output (default: 0)
+- $CM_PRIVACY: do not print clipboard content to standard out (default: 1)
 - $CM_OWN_CLIPBOARD: take ownership of the clipboard (default: 1)
 - $TMPDIR: specify the base directory to store the cache dir in (default: /tmp)
 EOF
@@ -114,8 +116,13 @@ while (( CM_ONESHOT )) || sleep "${CM_SLEEP:-0.5}"; do
 
         first_line=$(get_first_line "$data")
 
-        printf 'New clipboard entry on %s selection: "%s"\n' \
-            "$selection" "$first_line"
+        if (( CM_PRIVACY )); then
+            printf 'New clipboard entry on %s selection.\n' \
+                "$selection"
+        else
+            printf 'New clipboard entry on %s selection: "%s"\n' \
+                "$selection" "$first_line"
+        fi
 
         filename="$cache_dir/$(cksum <<< "$first_line")"
         debug "Writing $data to $filename"

--- a/init/clipmenud.service
+++ b/init/clipmenud.service
@@ -6,6 +6,7 @@ ExecStart=/usr/bin/clipmenud
 Restart=always
 RestartSec=0
 Environment=DISPLAY=:0
+Environment=CM_PRIVACY=1
 
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes


### PR DESCRIPTION
If the user uses the provided [clipmenud.service](https://github.com/cdown/clipmenu/blob/2cd2287612a541260e4a6973045479b354a4febf/init/clipmenud.service) unit, the systemd logs will contain a permanent list of all the previous contents of the clipboards. [This is because the content is printed to standard out every time something new is copied](https://github.com/cdown/clipmenu/blob/2cd2287612a541260e4a6973045479b354a4febf/clipmenud#L117-L118) and systemd logs standard out for services.

I implemented an option to clipmenud that disables printing the actual contents from the clipboard to standard out. I also added the environment variable to the systemd service unit file, to make sure it is active. Please give me feedback on anything you want to change, such as if this "privacy mode" should be default on or off. I left it on by default, but it's of course possible to have it off by default and have the systemd unit start with it either way.
