### PR TITLE
Allow use as a rofi script

### DIFF
--- a/clipmenu
+++ b/clipmenu
@@ -35,11 +35,11 @@ list_clips() {
 }
 
 if [[ "$CM_LAUNCHER" == rofi-script ]]; then
-    if [[ $# -eq 0 ]]; then
+    if ! (( $# )); then
         list_clips
         exit
     else
-        chosen_line="$1"
+        chosen_line="${@: -1}"
     fi
 else
     # It's okay to hardcode `-l 8` here as a sensible default without checking

--- a/clipmenu
+++ b/clipmenu
@@ -39,6 +39,8 @@ if [[ "$CM_LAUNCHER" == rofi-script ]]; then
         list_clips
         exit
     else
+        # https://github.com/koalaman/shellcheck/issues/1141
+        # shellcheck disable=SC2124
         chosen_line="${@: -1}"
     fi
 else

--- a/clipmenu
+++ b/clipmenu
@@ -30,14 +30,26 @@ if [[ "$CM_LAUNCHER" == rofi ]]; then
     set -- -dmenu "$@"
 fi
 
-# It's okay to hardcode `-l 8` here as a sensible default without checking
-# whether `-l` is also in "$@", because the way that dmenu works allows a later
-# argument to override an earlier one. That is, if the user passes in `-l`, our
-# one will be ignored.
-chosen_line=$(
-    cat "$cache_file_prefix"_* /dev/null | LC_ALL=C sort -rnk 1 |
-        cut -d' ' -f2- | awk '!seen[$0]++' | "$CM_LAUNCHER" -l 8 "$@"
-)
+list_clips() {
+    cat "$cache_file_prefix"_* /dev/null | LC_ALL=C sort -rnk 1 | cut -d' ' -f2- | awk '!seen[$0]++'
+}
+
+if [[ "$CM_LAUNCHER" == rofi-script ]]; then
+    if [[ -z "$@" ]]; then
+        list_clips
+        exit
+    else
+        chosen_line="$@"
+    fi
+else
+    # It's okay to hardcode `-l 8` here as a sensible default without checking
+    # whether `-l` is also in "$@", because the way that dmenu works allows a later
+    # argument to override an earlier one. That is, if the user passes in `-l`, our
+    # one will be ignored.
+    chosen_line=$(
+        list_clips | "$CM_LAUNCHER" -l 8 "$@"
+    )
+fi
 
 [[ $chosen_line ]] || exit 1
 

--- a/clipmenu
+++ b/clipmenu
@@ -35,11 +35,11 @@ list_clips() {
 }
 
 if [[ "$CM_LAUNCHER" == rofi-script ]]; then
-    if [[ -z "$@" ]]; then
+    if [[ $# -eq 0 ]]; then
         list_clips
         exit
     else
-        chosen_line="$@"
+        chosen_line="$1"
     fi
 else
     # It's okay to hardcode `-l 8` here as a sensible default without checking


### PR DESCRIPTION
Rofi has a mode called "script mode" where rofi itself launches the script. The script is expected to echo it's output to stdout then exit. When a selection is made, the script is called again, with the selected text as the first argument. This mode of operation allows rofi to show different scripts in multiple tabs (i.e. I have one rofi instance which is an application launcher AND a clipboard manager)