### PR TITLE
Configurable history length

### DIFF
--- a/clipmenu
+++ b/clipmenu
@@ -2,6 +2,7 @@
 
 : "${CM_LAUNCHER=dmenu}"
 : "${CM_DIR="${XDG_RUNTIME_DIR:-"${TMPDIR:-/tmp}"}"}"
+: "${CM_HISTLENGTH=8}"
 
 major_version=5
 
@@ -44,12 +45,8 @@ if [[ "$CM_LAUNCHER" == rofi-script ]]; then
         chosen_line="${@: -1}"
     fi
 else
-    # It's okay to hardcode `-l 8` here as a sensible default without checking
-    # whether `-l` is also in "$@", because the way that dmenu works allows a later
-    # argument to override an earlier one. That is, if the user passes in `-l`, our
-    # one will be ignored.
     chosen_line=$(
-        list_clips | "$CM_LAUNCHER" -l 8 "$@"
+        list_clips | "$CM_LAUNCHER" -l "${CM_HISTLENGTH}" "$@"
     )
 fi
 

--- a/clipmenu
+++ b/clipmenu
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 : "${CM_LAUNCHER=dmenu}"
-: "${CM_DIR="${XDG_RUNTIME_DIR-"${TMPDIR-/tmp}"}"}"
+: "${CM_DIR="${XDG_RUNTIME_DIR:-"${TMPDIR:-/tmp}"}"}"
 
 major_version=5
 
 shopt -s nullglob
 
-cache_dir=$CM_DIR/clipmenu.$major_version.$USER
-cache_file_prefix=$cache_dir/line_cache
+cache_dir="${CM_DIR}/clipmenu.${major_version}.${USER}"
+cache_file_prefix="${cache_dir}/line_cache"
 
 if [[ $1 == --help ]] || [[ $1 == -h ]]; then
     cat << 'EOF'


### PR DESCRIPTION
This PR introduces the environment variable `CM_HISTLENGTH` which may be used to configure the amount of displayed history.

It was hardcoded to `8` before, which was overridable with dmenu but not with rofi.

This change has been tested sucessfully with both dmenu and rofi.