### PR TITLE
Add support to ignore the clipboard in certain windows

### DIFF
--- a/clipmenud
+++ b/clipmenud
@@ -16,6 +16,7 @@ cache_file_prefix=$cache_dir/line_cache
 lock_file=$cache_dir/lock
 lock_timeout=2
 has_clipnotify=0
+has_xdotool=0
 
 # This comes from the environment, so we rely on word splitting.
 # shellcheck disable=SC2206
@@ -105,6 +106,12 @@ command -v clipnotify >/dev/null 2>&1 && has_clipnotify=1
 if ! (( has_clipnotify )); then
     echo "WARN: Consider installing clipnotify for better performance." >&2
     echo "WARN: See https://github.com/cdown/clipnotify." >&2
+fi
+
+command -v xdotool >/dev/null 2>&1 && has_xdotool=1
+
+if [[ "$CM_IGNORE_WINDOW" && ! (( has_xdotool )) ]]; then
+    echo "WARN: CM_IGNORE_WINDOW does not work without xdotool, which is not installed" >&2
 fi
 
 exec {lock_fd}> "$lock_file"

--- a/clipmenud
+++ b/clipmenud
@@ -129,10 +129,12 @@ while true; do
         fi
     fi
 
-    windowname="$(xdotool getactivewindow getwindowname)"
-    if [[ -n "${CM_IGNORE_WINDOW+x}" && "$windowname" =~ $CM_IGNORE_WINDOW ]]; then
-        debug "ignoring clipboard because windowname \"$windowname\" matches \"${CM_IGNORE_WINDOW}\""
-        continue
+    if [[ "${CM_IGNORE_WINDOW}" && (( has_xdotool ))]]; then
+        windowname="$(xdotool getactivewindow getwindowname)"
+        if [[ "$windowname" =~ $CM_IGNORE_WINDOW ]]; then
+            debug "ignoring clipboard because windowname \"$windowname\" matches \"${CM_IGNORE_WINDOW}\""
+            continue
+        fi
     fi
 
     if ! flock -x -w "$lock_timeout" "$lock_fd"; then

--- a/clipmenud
+++ b/clipmenud
@@ -86,6 +86,7 @@ Environment variables:
 - $CM_ONESHOT: run once immediately, do not loop (default: 0)
 - $CM_OWN_CLIPBOARD: take ownership of the clipboard (default: 1)
 - $CM_SELECTIONS: space separated list of the selections to manage (default: "clipboard primary")
+- $CM_IGNORE_WINDOW: disable recording the clipboard in windows where the windowname matches the given regex (e.g. a passwordmanager), do not ignore any windows if unset (default: unset)
 EOF
     exit 0
 fi
@@ -119,6 +120,12 @@ while true; do
             # Use old polling method
             "${sleep_cmd[@]}"
         fi
+    fi
+
+    windowname="$(xdotool getactivewindow getwindowname)"
+    if [[ -n "${CM_IGNORE_WINDOW+x}" && "$windowname" =~ $CM_IGNORE_WINDOW ]]; then
+        debug "ignoring clipboard because windowname \"$windowname\" matches \"${CM_IGNORE_WINDOW}\""
+        continue
     fi
 
     if ! flock -x -w "$lock_timeout" "$lock_fd"; then

--- a/clipmenud
+++ b/clipmenud
@@ -87,7 +87,7 @@ Environment variables:
 - $CM_ONESHOT: run once immediately, do not loop (default: 0)
 - $CM_OWN_CLIPBOARD: take ownership of the clipboard (default: 1)
 - $CM_SELECTIONS: space separated list of the selections to manage (default: "clipboard primary")
-- $CM_IGNORE_WINDOW: disable recording the clipboard in windows where the windowname matches the given regex (e.g. a passwordmanager), do not ignore any windows if unset (default: unset)
+- $CM_IGNORE_WINDOW: disable recording the clipboard in windows where the windowname matches the given regex (e.g. a password manager), do not ignore any windows if unset or empty (default: unset)
 EOF
     exit 0
 fi

--- a/clipmenud
+++ b/clipmenud
@@ -110,7 +110,7 @@ fi
 
 command -v xdotool >/dev/null 2>&1 && has_xdotool=1
 
-if [[ "$CM_IGNORE_WINDOW" && has_xdotool == 0 ]]; then
+if [[ $CM_IGNORE_WINDOW ]] && ! (( has_xdotool )); then
     echo "WARN: CM_IGNORE_WINDOW does not work without xdotool, which is not installed" >&2
 fi
 

--- a/clipmenud
+++ b/clipmenud
@@ -110,7 +110,7 @@ fi
 
 command -v xdotool >/dev/null 2>&1 && has_xdotool=1
 
-if [[ "$CM_IGNORE_WINDOW" && ! (( has_xdotool )) ]]; then
+if [[ "$CM_IGNORE_WINDOW" && has_xdotool == 0 ]]; then
     echo "WARN: CM_IGNORE_WINDOW does not work without xdotool, which is not installed" >&2
 fi
 

--- a/clipmenud
+++ b/clipmenud
@@ -129,7 +129,7 @@ while true; do
         fi
     fi
 
-    if [[ "${CM_IGNORE_WINDOW}" && (( has_xdotool ))]]; then
+    if [[ $CM_IGNORE_WINDOW ]] && (( has_xdotool )); then
         windowname="$(xdotool getactivewindow getwindowname)"
         if [[ "$windowname" =~ $CM_IGNORE_WINDOW ]]; then
             debug "ignoring clipboard because windowname \"$windowname\" matches \"${CM_IGNORE_WINDOW}\""


### PR DESCRIPTION
The clipboard does not get recorded when the title of the currenlty active
window matches the regular expression in CM_IGNORE_WINDOW. This allows copying
passwords from a password manager without the passwords ending up in clipmenu.

The matching is not 100% exact however, as there is a race condition bewteen the
time the clipboard is populated, clipmenu queries the clipboard, and the active
window gets queried. This race condition can be especially problematic when
using polling with large intervals instead of clipnotify.

This implements #86.