### PR TITLE
clipdel: Support getting pattern from standard input

### DIFF
--- a/clipdel
+++ b/clipdel
@@ -40,8 +40,6 @@ if ! [[ -f $cache_file ]]; then
     exit 0  # Well, this is a kind of success...
 fi
 
-# https://github.com/koalaman/shellcheck/issues/1141
-# shellcheck disable=SC2124
 raw_pattern=$1
 esc_pattern=${raw_pattern//\#/'\#'}
 

--- a/clipdel
+++ b/clipdel
@@ -19,7 +19,8 @@ lock_timeout=2
 if [[ $1 == --help ]] || [[ $1 == -h ]]; then
     cat << 'EOF'
 clipdel deletes clipmenu entries matching a regex. By default, just lists what
-it would delete, pass -d to do it for real.
+it would delete, pass -d to do it for real. If no pattern is passed as an argument,
+it will try to read one from standard input.
 
 ".*" is special, it will just nuke the entire data directory, including the
 line caches and all other state.
@@ -40,7 +41,12 @@ if ! [[ -f $cache_file ]]; then
     exit 0  # Well, this is a kind of success...
 fi
 
-raw_pattern=$1
+if [[ -n $1 ]]; then
+    raw_pattern=$1
+elif ! [[ -t 0 ]]; then
+    IFS= read -r raw_pattern
+fi
+
 esc_pattern=${raw_pattern//\#/'\#'}
 
 # We use 2 separate sed commands so "esc_pattern" matches only the 'clip' text


### PR DESCRIPTION
I'm using `clipmenu` together with `pass` (and `passmenu` :)), and
wanted to make sure that `pass` would remove passwords both from the
clipboard and the clipboard history.

I had to slightly patch `pass` for that locally, where I also figured it
would be best to simply pipe the password string into `clipdel`, instead
of passing it as an argument.

This patch makes `clipdel` look for a pattern coming from standard input
if there's no pattern passed as an argument.

Please review, and let me know if you need me to improve it, or to open
an issue instead for further discussions.