### PR TITLE
Fix clipdel cutting timestamps from file cache

### DIFF
--- a/clipdel
+++ b/clipdel
@@ -47,6 +47,10 @@ fi
 raw_pattern=$1
 esc_pattern=${raw_pattern//\#/'\#'}
 
+# We use 2 separate sed commands so "esc_pattern" matches only the 'clip' text
+# without the timestamp (e.g. $> clipdel '^delete_exact_match$')
+sed_common_command="s#^[0-9]\+ ##;\\#${esc_pattern}#"
+
 if ! [[ $raw_pattern ]]; then
     printf '%s\n' 'No pattern provided, see --help' >&2
     exit 2
@@ -60,8 +64,8 @@ if (( CM_REAL_DELETE )) && [[ "$raw_pattern" == ".*" ]]; then
     exit 0
 else
     mapfile -t matches < <(
-        cat "${line_cache_files[@]}" | cut -d' ' -f2- | sort -u |
-            sed -n "\\#${esc_pattern}#p"
+        sed -n "${sed_common_command}p" "${line_cache_files[@]}" |
+            sort -u
     )
 
     if (( CM_REAL_DELETE )); then
@@ -74,7 +78,11 @@ else
 
         for file in "${line_cache_files[@]}"; do
             temp=$(mktemp)
-            cut -d' ' -f2- < "$file" | sed "\\#${esc_pattern}#d" > "$temp"
+            # sed 'h' and 'g' here means save and restore the line, so
+            # timestamps are not removed from non-deleted lines. 'd' deletes the
+            # line and restarts, skipping 'g'/restore.
+            # https://www.gnu.org/software/sed/manual/html_node/Other-Commands.html#Other-Commands
+            sed "h;${sed_common_command}d;g" "$file" > "$temp"
             mv -- "$temp" "$file"
         done
 


### PR DESCRIPTION
The actual bug I encountered was that clipdel apparently re-ordered the clipmenu entries (seen when writing [my own clipmenu-del](https://github.com/Gravemind/dotfiles/blob/master/bin/clipmenu-del)).

Looking into it, I found clipdel `cut`ed the timestamp column from the line cache file!

So, I tried to fix this, and keep the pattern retro-compatible:
- still using the pattern in `sed`
- not using `sed -E`
- not break `clipdel -d '^exact_match$'` (the pattern is matched only against the text, without the timestamp).

Turns out sed is quite powerful, I discovered more [sed commands](https://www.gnu.org/software/sed/manual/html_node/Other-Commands.html#Other-Commands) that did the trick. But **there could be a better solution I didn't see**.

sed command `h` and `g` seems standard (at least [non-gnu compatible](http://netbsd.gw.com/cgi-bin/man-cgi?sed++NetBSD-current)), but **I did not actually test it with a non-gnu sed** (on bsd ?). 

Also, I thought of using `sed -i` instead of for+mktemp, but I know there might be compatibility issues with non-gnu-sed, so I dropped it...