### PR TITLE
Fix clipdel escaped only first '#'

### DIFF
--- a/clipdel
+++ b/clipdel
@@ -45,7 +45,7 @@ fi
 # https://github.com/koalaman/shellcheck/issues/1141
 # shellcheck disable=SC2124
 raw_pattern=$1
-esc_pattern=${raw_pattern/\#/'\#'}
+esc_pattern=${raw_pattern//\#/'\#'}
 
 if ! [[ $raw_pattern ]]; then
     printf '%s\n' 'No pattern provided, see --help' >&2


### PR DESCRIPTION
Clipdel only escapes the first '#'. Repro steps:
- copy and run `clipdel '#foo#'`, you get:

      sed: -e expression #1, char 9: comments don't accept any addresses

This PR fix this by using bash expansion subtlety, from [bash reference](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html):

> *${parameter/pattern/string}*
... If *pattern* begins with ‘/’, all matches of pattern are replaced with string...

