### PR TITLE
Run clipmenud after the display manager is started

### DIFF
--- a/init/clipmenud.service
+++ b/init/clipmenud.service
@@ -5,6 +5,7 @@ Description=Clipmenu daemon
 ExecStart=/usr/bin/clipmenud
 Restart=always
 RestartSec=500ms
+After=display-manager.service
 
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes


### PR DESCRIPTION
In cases of starting the display manager manually from tty, the DISPLAY variable is not yet set and clipmenud is crashing.