### PR TITLE
Use xdotool instead of cat when CM_OUTPUT_CLIP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # `dmenu` is not a hard dependency, but you need it unless
 # you plan to set CM_LAUNCHER to another value like `rofi`
-REQUIRED_BINS := xsel clipnotify
+REQUIRED_BINS := xsel xdotool clipnotify
 PREFIX ?= /usr
 $(foreach bin,$(REQUIRED_BINS),\
     $(if $(shell command -v $(bin) 2> /dev/null),$(info Found `$(bin)`),$(error Missing Dep. Please install `$(bin)`)))

--- a/clipmenu
+++ b/clipmenu
@@ -62,5 +62,5 @@ for selection in clipboard primary; do
 done
 
 if (( CM_OUTPUT_CLIP )); then
-    cat "$file"
+    xdotool key Shift+Insert
 fi

--- a/clipmenu
+++ b/clipmenu
@@ -23,7 +23,7 @@ Environment variables:
 - $CM_DIR: specify the base directory to store the cache dir in (default: $XDG_RUNTIME_DIR, $TMPDIR, or /tmp)
 - $CM_HISTLENGTH: specify the number of lines to show in dmenu/rofi (default: 8)
 - $CM_LAUNCHER: specify a dmenu-compatible launcher (default: dmenu)
-- $CM_OUTPUT_CLIP: if set, output clip selection to stdout
+- $CM_OUTPUT_CLIP: if set, output clip selection using xdotool
 EOF
     exit 0
 fi


### PR DESCRIPTION
This allows pasting directly in other non-terminal programs. For example a browser's address bar.