### PR TITLE
Preserve exit code from launcher

### DIFF
--- a/clipmenu
+++ b/clipmenu
@@ -58,6 +58,8 @@ else
     chosen_line=$(list_clips | "$CM_LAUNCHER" "${launcher_args[@]}" "$@")
 fi
 
+launcher_exit=$?
+
 [[ $chosen_line ]] || exit 1
 file=$cache_dir/$(cksum <<< "$chosen_line")
 [[ -f "$file" ]] || exit 2
@@ -69,3 +71,5 @@ done
 if (( CM_OUTPUT_CLIP )); then
     cat "$file"
 fi
+
+exit $launcher_exit

--- a/clipmenu
+++ b/clipmenu
@@ -56,9 +56,8 @@ if [[ "$CM_LAUNCHER" == rofi-script ]]; then
     fi
 else
     chosen_line=$(list_clips | "$CM_LAUNCHER" "${launcher_args[@]}" "$@")
+    launcher_exit=$?
 fi
-
-launcher_exit=$?
 
 [[ $chosen_line ]] || exit 1
 file=$cache_dir/$(cksum <<< "$chosen_line")
@@ -72,4 +71,4 @@ if (( CM_OUTPUT_CLIP )); then
     cat "$file"
 fi
 
-exit $launcher_exit
+[ -n "$launcher_exit" ] && exit "$launcher_exit"

--- a/clipmenu
+++ b/clipmenu
@@ -71,4 +71,4 @@ if (( CM_OUTPUT_CLIP )); then
     cat "$file"
 fi
 
-[ -n "$launcher_exit" ] && exit "$launcher_exit"
+exit "${launcher_exit:-"$?"}"


### PR DESCRIPTION
This change is related to https://github.com/cdown/clipmenu/issues/57#issuecomment-740123283.

If `clipmenu` "preserves" the exit code from the launcher (exits with the same code as the launcher), the exit codes from Rofi's custom keybindings can be used with `clipmenu`.

For example, I'm using the following script bound to `Super+v`:
```bash
#!/bin/bash

trap "exit" INT

# Run clipmenu
CM_LAUNCHER=rofi clipmenu -p "Paste" -mesg "Use Shift+Delete to delete an item" \
    -kb-delete-entry "" -kb-custom-1 "Shift+Delete" \
    -kb-accept-alt "" -kb-custom-2 "Shift+Return"

exit_code=$?

case $exit_code in
    0) xdotool key "shift+Insert" ;;
    10) clipdel -d ^"$(xsel -b)"$; "$0" ;;
    *) exit $exit_code ;;
esac
```

With the above script, I have 3 different options when running `clipmenu`:
- if I press `Return`, the selected item is pasted to where my cursor currently is (a bit hackily with `xdotool`)
- if I press `Shift+Return`, the selected item is sent to the clipboard ("default" `clipmenu` behavior)
- if I press `Shift+Delete`, the selected item is deleted from `clipmenu`, and the script runs itself again (essentially keeps `clipmenu` open)

In order for this to work, the only change needed in `clipmenu` is to preserve the exit codes from the custom keybindings.