### PR TITLE
Added commands to clipctl to check the status, toggle, get version and directory

### DIFF
--- a/clipctl
+++ b/clipctl
@@ -1,27 +1,64 @@
 #!/usr/bin/env bash
 
+: "${CM_DIR:="${XDG_RUNTIME_DIR-"${TMPDIR-/tmp}"}"}"
+
 if [[ -z $1 ]] || [[ $1 == --help ]] || [[ $1 == -h ]]; then
     cat << 'EOF'
 clipctl provides controls for the clipmenud daemon.
 
 You can temporarily disable clip collection without stopping clipmenud entirely
 by running "clipctl disable". You can then reenable with "clipctl enable".
+
+Commands:
+    enable: enable clip collection
+    disable: disable clip collection
+    status: returns "enabled" or "disabled"
+    toggle: toggles clip collection
+    version: returns major version
+    cm-dir: returns the directory used for caching
 EOF
     exit 0
 fi
 
+_MAJORVERSION=6
 _CLIPMENUD_PID=$(pgrep -u "$(id -u)" -nf 'clipmenud$')
+_CLIPMENUCACHEDIR=$CM_DIR/clipmenu.$_MAJORVERSION.$USER
+_CLIPMENUSTATUSFILE=$_CLIPMENUCACHEDIR/status
 
-if [[ -z "$_CLIPMENUD_PID" ]]; then
-    echo "clipmenud is not running"
-    exit 2
-fi
+case $1 in
+    enable|disable|toggle)
+        if [[ -z "$_CLIPMENUD_PID" ]]; then
+            echo "clipmenud is not running"
+            exit 2
+        fi
+        ;;
+esac
 
 case $1 in
     enable) kill -USR2 "$_CLIPMENUD_PID" ;;
     disable) kill -USR1 "$_CLIPMENUD_PID" ;;
+    status)
+        if ! [[ $(pgrep -f "clipmenud") ]]; then
+            echo "disabled"
+            exit
+        fi
+        if [[ -e $_CLIPMENUSTATUSFILE ]]; then
+            echo $(cat $_CLIPMENUSTATUSFILE)
+        else
+            echo "enabled"
+        fi
+        ;;
+    toggle)
+        if [[ $(clipctl status) == "enabled" ]]; then
+            clipctl disable
+        else
+            clipctl enable
+        fi
+        ;;
+    version) echo $_MAJORVERSION ;;
+    cm-dir) echo $_CLIPMENUCACHEDIR ;;
     *)
         printf 'Unknown command: %s\n' "$1"
         exit 1
-    ;;
+        ;;
 esac

--- a/clipctl
+++ b/clipctl
@@ -15,50 +15,41 @@ Commands:
     status: returns "enabled" or "disabled"
     toggle: toggles clip collection
     version: returns major version
-    cm-dir: returns the directory used for caching
+    cache-dir: returns the directory used for caching
 EOF
     exit 0
 fi
 
-_MAJORVERSION=6
-_CLIPMENUD_PID=$(pgrep -u "$(id -u)" -nf 'clipmenud$')
-_CLIPMENUCACHEDIR=$CM_DIR/clipmenu.$_MAJORVERSION.$USER
-_CLIPMENUSTATUSFILE=$_CLIPMENUCACHEDIR/status
+clipmenud_pid=$(pgrep -u "$(id -u)" -nf 'clipmenud$')
 
 case $1 in
-    enable|disable|toggle)
-        if [[ -z "$_CLIPMENUD_PID" ]]; then
+    enable|disable|toggle|status)
+        if [[ -z "$clipmenud_pid" ]]; then
             echo "clipmenud is not running"
             exit 2
         fi
         ;;
 esac
 
+major_version=6
+cache_dir=$CM_DIR/clipmenu.$major_version.$USER
+status_file=$cache_dir/status
+
 case $1 in
-    enable) kill -USR2 "$_CLIPMENUD_PID" ;;
-    disable) kill -USR1 "$_CLIPMENUD_PID" ;;
-    status)
-        if ! [[ $(pgrep -f "clipmenud") ]]; then
-            echo "disabled"
-            exit
-        fi
-        if [[ -e $_CLIPMENUSTATUSFILE ]]; then
-            echo $(cat $_CLIPMENUSTATUSFILE)
-        else
-            echo "enabled"
-        fi
-        ;;
+    enable) kill -USR2 "$clipmenud_pid" ;;
+    disable) kill -USR1 "$clipmenud_pid" ;;
+    status) cat $status_file ;;
     toggle)
         if [[ $(clipctl status) == "enabled" ]]; then
             clipctl disable
         else
             clipctl enable
         fi
-        ;;
-    version) echo $_MAJORVERSION ;;
-    cm-dir) echo $_CLIPMENUCACHEDIR ;;
+    ;;
+    version) echo $major_version ;;
+    cache-dir) echo $cache_dir ;;
     *)
         printf 'Unknown command: %s\n' "$1"
         exit 1
-        ;;
+    ;;
 esac

--- a/clipctl
+++ b/clipctl
@@ -6,9 +6,6 @@ if [[ -z $1 ]] || [[ $1 == --help ]] || [[ $1 == -h ]]; then
     cat << 'EOF'
 clipctl provides controls for the clipmenud daemon.
 
-You can temporarily disable clip collection without stopping clipmenud entirely
-by running "clipctl disable". You can then reenable with "clipctl enable".
-
 Commands:
     enable: enable clip collection
     disable: disable clip collection
@@ -38,7 +35,7 @@ status_file=$cache_dir/status
 case $1 in
     enable) kill -USR2 "$clipmenud_pid" ;;
     disable) kill -USR1 "$clipmenud_pid" ;;
-    status) cat $status_file ;;
+    status) cat "$status_file" ;;
     toggle)
         if [[ $(clipctl status) == "enabled" ]]; then
             clipctl disable
@@ -46,8 +43,8 @@ case $1 in
             clipctl enable
         fi
     ;;
-    version) echo $major_version ;;
-    cache-dir) echo $cache_dir ;;
+    version) echo "$major_version" ;;
+    cache-dir) echo "$cache_dir" ;;
     *)
         printf 'Unknown command: %s\n' "$1"
         exit 1

--- a/clipdel
+++ b/clipdel
@@ -8,7 +8,7 @@ fi
 
 shopt -s nullglob
 
-cache_dir=$(clipctl cm-dir)
+cache_dir=$(clipctl cache-dir)
 cache_file=$cache_dir/line_cache
 lock_file=$cache_dir/lock
 lock_timeout=2

--- a/clipdel
+++ b/clipdel
@@ -1,17 +1,14 @@
 #!/usr/bin/env bash
 
-: "${CM_DIR="${XDG_RUNTIME_DIR-"${TMPDIR-/tmp}"}"}"
 CM_REAL_DELETE=0
 if [[ $1 == -d ]]; then
     CM_REAL_DELETE=1
     shift
 fi
 
-major_version=6
-
 shopt -s nullglob
 
-cache_dir=$CM_DIR/clipmenu.$major_version.$USER
+cache_dir=$(clipctl cm-dir)
 cache_file=$cache_dir/line_cache
 lock_file=$cache_dir/lock
 lock_timeout=2

--- a/clipfsck
+++ b/clipfsck
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
-: "${CM_DIR="${XDG_RUNTIME_DIR-"${TMPDIR-/tmp}"}"}"
-
-major_version=6
-
 shopt -s nullglob
 
-cache_dir=$CM_DIR/clipmenu.$major_version.$USER
+cache_dir=$(clipctl cm-dir)
 cache_file=$cache_dir/line_cache
 
 declare -A cksums

--- a/clipfsck
+++ b/clipfsck
@@ -2,7 +2,7 @@
 
 shopt -s nullglob
 
-cache_dir=$(clipctl cm-dir)
+cache_dir=$(clipctl cache-dir)
 cache_file=$cache_dir/line_cache
 
 declare -A cksums

--- a/clipmenu
+++ b/clipmenu
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 
 : "${CM_LAUNCHER=dmenu}"
-: "${CM_DIR="${XDG_RUNTIME_DIR-"${TMPDIR-/tmp}"}"}"
 : "${CM_HISTLENGTH=8}"
-
-major_version=6
 
 shopt -s nullglob
 
-cache_dir=$CM_DIR/clipmenu.$major_version.$USER
+cache_dir=$(clipctl cm-dir)
 cache_file=$cache_dir/line_cache
 
 # Not -h, see #142

--- a/clipmenu
+++ b/clipmenu
@@ -5,7 +5,7 @@
 
 shopt -s nullglob
 
-cache_dir=$(clipctl cm-dir)
+cache_dir=$(clipctl cache-dir)
 cache_file=$cache_dir/line_cache
 
 # Not -h, see #142

--- a/clipmenud
+++ b/clipmenud
@@ -4,7 +4,6 @@
 : "${CM_OWN_CLIPBOARD=0}"
 : "${CM_SYNC_PRIMARY_TO_CLIPBOARD=0}"
 : "${CM_DEBUG=0}"
-: "${CM_DIR:="${XDG_RUNTIME_DIR-"${TMPDIR-/tmp}"}"}"
 
 : "${CM_MAX_CLIPS:=1000}"
 # Buffer to batch to avoid calling too much. Only used if CM_MAX_CLIPS >0.
@@ -13,9 +12,10 @@ CM_MAX_CLIPS_THRESH=$(( CM_MAX_CLIPS + 10 ))
 : "${CM_SELECTIONS:=clipboard primary}"
 read -r -a selections <<< "$CM_SELECTIONS"
 
-major_version=6
-cache_dir=$CM_DIR/clipmenu.$major_version.$USER/
+cache_dir=$(clipctl cm-dir)
 cache_file=$cache_dir/line_cache
+status_file=$cache_dir/status
+echo "enabled" > $status_file
 
 # lock_file: lock for *one* iteration of clipboard capture/propagation
 # session_lock_file: lock to prevent multiple clipmenud daemons
@@ -60,6 +60,7 @@ sig_disable() {
     info "Received disable signal, suspending clipboard capture"
     _CM_DISABLED=1
     _CM_FIRST_DISABLE=1
+    echo "disabled" > $status_file
     [[ -v _CM_CLIPNOTIFY_PID ]] && kill "$_CM_CLIPNOTIFY_PID"
 }
 
@@ -78,6 +79,7 @@ sig_enable() {
 
     info "Received enable signal, resuming clipboard capture"
     _CM_DISABLED=0
+    echo "enabled" > $status_file
 }
 
 kill_background_jobs() {

--- a/clipmenud
+++ b/clipmenud
@@ -12,10 +12,10 @@ CM_MAX_CLIPS_THRESH=$(( CM_MAX_CLIPS + 10 ))
 : "${CM_SELECTIONS:=clipboard primary}"
 read -r -a selections <<< "$CM_SELECTIONS"
 
-cache_dir=$(clipctl cm-dir)
+cache_dir=$(clipctl cache-dir)
 cache_file=$cache_dir/line_cache
 status_file=$cache_dir/status
-echo "enabled" > $status_file
+echo "enabled" > "$status_file"
 
 # lock_file: lock for *one* iteration of clipboard capture/propagation
 # session_lock_file: lock to prevent multiple clipmenud daemons
@@ -60,7 +60,7 @@ sig_disable() {
     info "Received disable signal, suspending clipboard capture"
     _CM_DISABLED=1
     _CM_FIRST_DISABLE=1
-    echo "disabled" > $status_file
+    echo "disabled" > "$status_file"
     [[ -v _CM_CLIPNOTIFY_PID ]] && kill "$_CM_CLIPNOTIFY_PID"
 }
 
@@ -79,7 +79,7 @@ sig_enable() {
 
     info "Received enable signal, resuming clipboard capture"
     _CM_DISABLED=0
-    echo "enabled" > $status_file
+    echo "enabled" > "$status_file"
 }
 
 kill_background_jobs() {

--- a/tests/test-clipmenu
+++ b/tests/test-clipmenu
@@ -4,10 +4,7 @@ set -x
 set -e
 set -o pipefail
 
-: "${CM_DIR="${XDG_RUNTIME_DIR-"${TMPDIR-/tmp}"}"}"
-
-major_version=6
-dir=$CM_DIR/clipmenu.$major_version.$USER
+dir=$(clipctl cm-dir)
 cache_file=$dir/line_cache
 
 if [[ $0 == /* ]]; then

--- a/tests/test-clipmenu
+++ b/tests/test-clipmenu
@@ -4,7 +4,7 @@ set -x
 set -e
 set -o pipefail
 
-dir=$(clipctl cm-dir)
+dir=$(clipctl cache-dir)
 cache_file=$dir/line_cache
 
 if [[ $0 == /* ]]; then

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 
-major_version=6
-
 msg() {
     printf '>>> %s\n' "$@" >&2
 }
 
-: "${CM_DIR="${XDG_RUNTIME_DIR-"${TMPDIR-/tmp}"}"}"
-
-dir=$CM_DIR/clipmenu.$major_version.$USER
+dir=$(clipctl cm-dir)
 cache_file=$dir/line_cache
 
 log=$(mktemp)

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -4,7 +4,7 @@ msg() {
     printf '>>> %s\n' "$@" >&2
 }
 
-dir=$(clipctl cm-dir)
+dir=$(clipctl cache-dir)
 cache_file=$dir/line_cache
 
 log=$(mktemp)


### PR DESCRIPTION
This adds four new commands to `clipctl`, solving #151:
* `status`: returns "enabled" or "disabled"
* `toggle`: toggles clip collection
* `version`: returns major version
* `cm-dir`: returns the directory used for caching

I also changed other files to get the cache directory from `clipctl cm-dir`. I found this nicer to have it in one place, rather than having to have the correct folder set in each file. However, this is not required and I can revert that if you don't like it.