### PR TITLE
Add backup functionality

### DIFF
--- a/clipctl
+++ b/clipctl
@@ -13,6 +13,7 @@ Commands:
     toggle: toggles clip collection
     version: returns major version
     cache-dir: returns the directory used for caching
+    backup: copy the current clip collection to a user-defined location
 EOF
     exit 0
 fi
@@ -45,6 +46,12 @@ case $1 in
     ;;
     version) echo "$major_version" ;;
     cache-dir) echo "$cache_dir" ;;
+    backup)
+        read -p "Enter the full path to the backup directory: " backup_dir
+        cp "$cache_dir"/* "$backup_dir"
+        mv "$backup_dir"/line_cache "$backup_dir"/line_backup
+        rm "$backup_dir"/session_lock "$backup_dir"/status "$backup_dir"/lock
+    ;;
     *)
         printf 'Unknown command: %s\n' "$1" >&2
         exit 1

--- a/clipmenud
+++ b/clipmenud
@@ -121,8 +121,8 @@ mkdir -p -m0700 "$cache_dir"
 echo "enabled" > "$status_file"
 
 if  ! [[ -z CM_BACKUP ]]; then
-  cp "$CM_BACKUP"/* "$cache_dir"
-  mv "$cache_dir"/line_backup "$cache_file"
+  cp -R "$CM_BACKUP/." "$cache_dir"
+  mv "$cache_dir/line_backup" "$cache_file"
 fi
 
 exec {session_lock_fd}> "$session_lock_file"

--- a/clipmenud
+++ b/clipmenud
@@ -108,6 +108,7 @@ Environment variables:
 - $CM_SELECTIONS: space separated list of the selections to manage (default: "clipboard primary")
 - $CM_SYNC_PRIMARY_TO_CLIPBOARD: sync selections from primary to clipboard immediately (default: 0)
 - $CM_IGNORE_WINDOW: disable recording the clipboard in windows where the windowname matches the given regex (e.g. a password manager), do not ignore any windows if unset or empty (default: unset)
+- $CM_BACKUP: if path to backup directory is specified, its contents will be imported to the clip collection upon daemon startup 
 EOF
     exit 0
 fi
@@ -118,6 +119,11 @@ fi
 # shellcheck disable=SC2174
 mkdir -p -m0700 "$cache_dir"
 echo "enabled" > "$status_file"
+
+if  ! [[ -z CM_BACKUP ]]; then
+  cp "$CM_BACKUP"/* "$cache_dir"
+  mv "$CM_BACKUP"/line_backup "$cache_file"
+fi
 
 exec {session_lock_fd}> "$session_lock_file"
 flock -x -n "$session_lock_fd" ||

--- a/clipmenud
+++ b/clipmenud
@@ -122,7 +122,7 @@ echo "enabled" > "$status_file"
 
 if  ! [[ -z CM_BACKUP ]]; then
   cp "$CM_BACKUP"/* "$cache_dir"
-  mv "$CM_BACKUP"/line_backup "$cache_file"
+  mv "$cache_dir"/line_backup "$cache_file"
 fi
 
 exec {session_lock_fd}> "$session_lock_file"


### PR DESCRIPTION
I needed a way to make (part of) my clipboard permanent, so I added a rudimentary backup function to clipctl and a handler for the CM_BACKUP environmental variable (full path to backup directory) in clipmenud.