### PR TITLE
Add ability to bypass clipmenu for choosing selection

### DIFF
--- a/clipmenu
+++ b/clipmenu
@@ -50,7 +50,8 @@ fi
 launcher_args=(-l "${CM_HISTLENGTH}")
 
 if (( CM_INPUT_CLIP )); then
-    chosen_line="$( cat )"
+    read
+    chosen_line="$REPLY"
 else
     # Blacklist of non-dmenu launchers
     launcher_args=(-l "${CM_HISTLENGTH}")

--- a/clipmenu
+++ b/clipmenu
@@ -47,23 +47,30 @@ fi
 
 # Blacklist of non-dmenu launchers
 launcher_args=(-l "${CM_HISTLENGTH}")
-if [[ "$CM_LAUNCHER" == fzf ]]; then
-    launcher_args=()
-fi
 
-# rofi supports dmenu-like arguments through the -dmenu flag
-[[ "$CM_LAUNCHER" == rofi ]] && set -- -dmenu "$@"
-
-if [[ "$CM_LAUNCHER" == rofi-script ]]; then
-    if (( $# )); then
-        chosen_line="${!#}"
-    else
-        list_clips
-        exit
-    fi
+if (( CM_INPUT_CLIP )); then
+    chosen_line="$( cat )"
 else
-    chosen_line=$(list_clips | "$CM_LAUNCHER" "${launcher_args[@]}" "$@")
-    launcher_exit=$?
+    # Blacklist of non-dmenu launchers
+    launcher_args=(-l "${CM_HISTLENGTH}")
+    if [[ "$CM_LAUNCHER" == fzf ]]; then
+        launcher_args=()
+    fi
+
+    # rofi supports dmenu-like arguments through the -dmenu flag
+    [[ "$CM_LAUNCHER" == rofi ]] && set -- -dmenu "$@"
+
+    if [[ "$CM_LAUNCHER" == rofi-script ]]; then
+        if (( $# )); then
+            chosen_line="${!#}"
+        else
+            list_clips
+            exit
+        fi
+    else
+        chosen_line=$(list_clips | "$CM_LAUNCHER" "${launcher_args[@]}" "$@")
+        launcher_exit=$?
+    fi
 fi
 
 [[ $chosen_line ]] || exit 1

--- a/clipmenu
+++ b/clipmenu
@@ -21,6 +21,7 @@ Environment variables:
 - $CM_HISTLENGTH: specify the number of lines to show in dmenu/rofi (default: 8)
 - $CM_LAUNCHER: specify a dmenu-compatible launcher (default: dmenu)
 - $CM_OUTPUT_CLIP: if set, output clip selection to stdout
+- $CM_INPUT_CLIP: if set, accept clip selection from stdin
 EOF
     exit 0
 }

--- a/clipmenu
+++ b/clipmenu
@@ -30,15 +30,9 @@ list_clips() {
     LC_ALL=C sort -rnk 1 < "$cache_file" | cut -d' ' -f2- | awk '!seen[$0]++'
 }
 
-print_sel(){
-    list_clips
-    exit 0
-}
-
 case "$1" in
     # Not -h, see #142
     --help) print_help ;;
-    --print-sel) print_sel ;;
 esac
 
 if ! [[ -f "$cache_file" ]]; then
@@ -69,6 +63,9 @@ else
             list_clips
             exit
         fi
+    elif [[ "$CM_LAUNCHER" == cat ]]; then
+        list_clips
+        exit 0
     else
         chosen_line=$(list_clips | "$CM_LAUNCHER" "${launcher_args[@]}" "$@")
         launcher_exit=$?

--- a/clipmenu
+++ b/clipmenu
@@ -8,8 +8,7 @@ shopt -s nullglob
 cache_dir=$(clipctl cache-dir)
 cache_file=$cache_dir/line_cache
 
-# Not -h, see #142
-if [[ $1 == --help ]]; then
+print_help(){
     cat << 'EOF'
 clipmenu is a simple clipboard manager using dmenu and xsel. Launch this
 when you want to select a clip.
@@ -24,7 +23,22 @@ Environment variables:
 - $CM_OUTPUT_CLIP: if set, output clip selection to stdout
 EOF
     exit 0
-fi
+}
+
+list_clips() {
+    LC_ALL=C sort -rnk 1 < "$cache_file" | cut -d' ' -f2- | awk '!seen[$0]++'
+}
+
+print_sel(){
+    list_clips
+    exit 0
+}
+
+case "$1" in
+    # Not -h, see #142
+    --help) print_help ;;
+    --print-sel) print_sel ;;
+esac
 
 if ! [[ -f "$cache_file" ]]; then
     printf '%s\n' 'No cache file yet, did you run clipmenud?'
@@ -39,10 +53,6 @@ fi
 
 # rofi supports dmenu-like arguments through the -dmenu flag
 [[ "$CM_LAUNCHER" == rofi ]] && set -- -dmenu "$@"
-
-list_clips() {
-    LC_ALL=C sort -rnk 1 < "$cache_file" | cut -d' ' -f2- | awk '!seen[$0]++'
-}
 
 if [[ "$CM_LAUNCHER" == rofi-script ]]; then
     if (( $# )); then


### PR DESCRIPTION
Add 2 new options:
1) --print-sel argument to print all selections in clipmenu
2) CM_INPUT_CLIP to accept selection from stdin

The reasoning behind this is to bypass clipmenu for getting a selection.
For example: `clipmenu --print-sel | fzf | CM_INPUT_CLIP=1 clipmenu`

For my user case I found a need for it so I can preprocess the output of fzf before piping it back into clipmenu.
This is because fzf prints out extra information, apart from the selection, in some circumstances and clipmenu can't handle with such a scenario.