### PR TITLE
Add new clipcli to seperate clipboard management from dmenu

### DIFF
--- a/clipcli
+++ b/clipcli
@@ -41,8 +41,8 @@ get_clip(){
 case "$1" in
     # Not -h, see #142
     -h|--help) print_help ;;
-    -l|--list) list_clips; exit 0 ;;
-    -g|--get) get_clip "$2"; exit 0 ;;
+    list) list_clips; exit 0 ;;
+    get) get_clip "$2"; exit 0 ;;
 esac
 
 

--- a/clipcli
+++ b/clipcli
@@ -32,7 +32,12 @@ list_clips() {
 }
 
 get_clip(){
-    [ $1 ] && clip_line="$1" || read; clip_line="$REPLY"
+    if [[ -n $1 ]]; then
+        clip_line="$1"
+    else
+        read;
+        clip_line="$REPLY"
+    fi
     file=$cache_dir/$(cksum <<< "$clip_line")
     [[ -f "$file" ]] || exit 2
     cat "$file"

--- a/clipcli
+++ b/clipcli
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# CLI for listing and retrieving clips
+
+: "${CM_DIR="${XDG_RUNTIME_DIR-"${TMPDIR-/tmp}"}"}"
+
+major_version=6
+
+shopt -s nullglob
+
+cache_dir=$CM_DIR/clipmenu.$major_version.$USER
+cache_file=$cache_dir/line_cache
+
+if ! [[ -f "$cache_file" ]]; then
+    printf '%s\n' 'No cache file yet, did you run clipmenud?'
+    exit 2
+fi
+
+print_help(){
+    cat << 'EOF'
+clipmenu is a simple clipboard manager using dmenu and xsel. Launch this
+when you want to select a clip.
+All arguments are passed through to dmenu itself.
+Environment variables:
+- $CM_DIR: specify the base directory to store the cache dir in (default: $XDG_RUNTIME_DIR, $TMPDIR, or /tmp)
+EOF
+    exit 0
+}
+
+list_clips() {
+    LC_ALL=C sort -rnk 1 < "$cache_file" | cut -d' ' -f2- | awk '!seen[$0]++'
+}
+
+get_clip(){
+    [ $1 ] && clip_line="$1" || read; clip_line="$REPLY"
+    file=$cache_dir/$(cksum <<< "$clip_line")
+    [[ -f "$file" ]] || exit 2
+    cat "$file"
+}
+
+case "$1" in
+    # Not -h, see #142
+    -h|--help) print_help ;;
+    -l|--list) list_clips; exit 0 ;;
+    -g|--get) get_clip "$2"; exit 0 ;;
+esac
+
+

--- a/clipmenu
+++ b/clipmenu
@@ -49,8 +49,6 @@ else
 fi
 
 [[ $chosen_line ]] || exit 1
-# file=$cache_dir/$(cksum <<< "$chosen_line")
-# [[ -f "$file" ]] || exit 2
 clip(){ clipcli get "$chosen_line"; }
 
 for selection in clipboard primary; do

--- a/clipmenu
+++ b/clipmenu
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 : "${CM_LAUNCHER=dmenu}"
-: "${CM_DIR="${XDG_RUNTIME_DIR-"${TMPDIR-/tmp}"}"}"
 : "${CM_HISTLENGTH=8}"
 
 major_version=6
@@ -38,29 +37,26 @@ fi
 # rofi supports dmenu-like arguments through the -dmenu flag
 [[ "$CM_LAUNCHER" == rofi ]] && set -- -dmenu "$@"
 
-list_clips() {
-    LC_ALL=C sort -rnk 1 < "$cache_file" | cut -d' ' -f2- | awk '!seen[$0]++'
-}
-
 if [[ "$CM_LAUNCHER" == rofi-script ]]; then
     if (( $# )); then
         chosen_line="${!#}"
     else
-        list_clips
+        clipcli list
         exit
     fi
 else
-    chosen_line=$(list_clips | "$CM_LAUNCHER" "${launcher_args[@]}" "$@")
+    chosen_line=$(clipcli list | "$CM_LAUNCHER" "${launcher_args[@]}" "$@")
 fi
 
 [[ $chosen_line ]] || exit 1
-file=$cache_dir/$(cksum <<< "$chosen_line")
-[[ -f "$file" ]] || exit 2
+# file=$cache_dir/$(cksum <<< "$chosen_line")
+# [[ -f "$file" ]] || exit 2
+clip(){ clipcli get "$chosen_line"; }
 
 for selection in clipboard primary; do
-    xsel --logfile /dev/null -i --"$selection" < "$file"
+    clip | xsel --logfile /dev/null -i --"$selection"
 done
 
 if (( CM_OUTPUT_CLIP )); then
-    cat "$file"
+    clip
 fi


### PR DESCRIPTION
So this is my improved solution to a a problem I solved in #161 

I have added a new script called `clipcli` which handles the clipboard management.
It has 2 commands
- `clipcli list`: prints a list of clips.
- `clipcli get`: retrieves a clip based on its input.

So you can build your own scripts using `clipcli list | fzf | clipcli get`

I think this is a better solution because I believe that the clipboard management should be independent of whatever menu of fuzzy finder you use.

I have converted clipmenu to use the new script but kept the cli of clipmenu the same for backwards compatibility, but I think it may be a good idea to depreciate it and introduce separate scripts for dmenu, fzf, rofi etc

This would allow people to build their own scripts more easily, as a possible suggestion you could have a new dir in this repo or another repo with user scrips people can publish.

This was made in a bit of a rush, so I might have missed some things.