### PR TITLE
clipmenud: fix killing background jobs by unquoting variable

### DIFF
--- a/clipmenud
+++ b/clipmenud
@@ -86,11 +86,11 @@ kill_background_jobs() {
     # group leader. As such, all we can do is look at the pending jobs. Bash
     # avoids a subshell here, so the job list is in the right shell.
     local bg
-    bg=$(jobs -p)
+    bg=( $(jobs -p) )
 
     # Don't log `kill' failures, since with KillMode=control-group, we're
     # racing with init.
-    [[ $bg ]] && kill -- $bg 2>/dev/null
+    [[ $bg ]] && kill -- ${bg[*]} 2>/dev/null
 }
 
 if [[ $1 == --help ]] || [[ $1 == -h ]]; then

--- a/clipmenud
+++ b/clipmenud
@@ -91,9 +91,7 @@ kill_background_jobs() {
 
     # Don't log `kill' failures, since with KillMode=control-group, we're
     # racing with init.
-    for i in ${!bg[@]}; do
-        kill -- ${bg[i]} 2>/dev/null
-    done
+    kill -- "${bg[@]}" 2>/dev/null
 }
 
 if [[ $1 == --help ]] || [[ $1 == -h ]]; then

--- a/clipmenud
+++ b/clipmenud
@@ -85,12 +85,15 @@ kill_background_jobs() {
     # While we usually _are_, there are no guarantees that we're the process
     # group leader. As such, all we can do is look at the pending jobs. Bash
     # avoids a subshell here, so the job list is in the right shell.
-    local bg
-    bg=( $(jobs -p) )
+    local -a bg
+
+    readarray -t bg < <(jobs -p)
 
     # Don't log `kill' failures, since with KillMode=control-group, we're
     # racing with init.
-    [[ $bg ]] && kill -- ${bg[*]} 2>/dev/null
+    for i in ${!bg[@]}; do
+        kill -- ${bg[i]} 2>/dev/null
+    done
 }
 
 if [[ $1 == --help ]] || [[ $1 == -h ]]; then

--- a/clipmenud
+++ b/clipmenud
@@ -90,7 +90,7 @@ kill_background_jobs() {
 
     # Don't log `kill' failures, since with KillMode=control-group, we're
     # racing with init.
-    [[ $bg ]] && kill -- "$bg" 2>/dev/null
+    [[ $bg ]] && kill -- $bg 2>/dev/null
 }
 
 if [[ $1 == --help ]] || [[ $1 == -h ]]; then

--- a/clipmenud
+++ b/clipmenud
@@ -91,7 +91,7 @@ kill_background_jobs() {
 
     # Don't log `kill' failures, since with KillMode=control-group, we're
     # racing with init.
-    kill -- "${bg[@]}" 2>/dev/null
+    (( ${#bg[@]} )) && kill -- "${bg[@]}" 2>/dev/null
 }
 
 if [[ $1 == --help ]] || [[ $1 == -h ]]; then


### PR DESCRIPTION
Hello,

I found out that a variable storing the multiline result of `jobs -p` should not be quoted when it's used as sequence of arguments.

Here I propose a trivial fix... to just unquote the variable.

This allows to properly kill all children jobs.

```
$ jobs -p
7345
7862

$ bg=$(jobs -p)

$ echo $bg
7345 7862

$ echo "$bg"
7345
7862

Correct:
$ kill -- $bg
$ kill -- 7345 7862

Wrong:
$ kill -- "$bg"
$ kill -- "7345"$'\n'"7862"
```