### PR TITLE
clipmenud: prevent spawning more clipnotify jobs

### DIFF
--- a/clipmenud
+++ b/clipmenud
@@ -58,9 +58,7 @@ debug() { (( CM_DEBUG )) && printf '%s\n' "$@" >&2; }
 sig_disable() {
     info "Received disable signal, suspending clipboard capture"
     _CM_DISABLED=1
-    _CM_FIRST_DISABLE=1
     echo "disabled" > "$status_file"
-    [[ -v _CM_CLIPNOTIFY_PID ]] && kill "$_CM_CLIPNOTIFY_PID"
 }
 
 sig_enable() {
@@ -135,8 +133,8 @@ fi
 
 exec {lock_fd}> "$lock_file"
 
-trap sig_disable USR1
-trap sig_enable USR2
+trap '_CM_TRAP=1; sig_disable' USR1
+trap '_CM_TRAP=1; sig_enable' USR2
 trap 'trap - INT TERM EXIT; kill_background_jobs; exit 0' INT TERM EXIT
 
 while true; do
@@ -147,13 +145,16 @@ while true; do
         wait "$_CM_CLIPNOTIFY_PID"
     fi
 
+    # Trapping a signal breaks the `wait`
+    if (( _CM_TRAP )); then
+        # Prevent spawning another clipnotify job restarting the loop
+        kill_background_jobs
+        unset _CM_TRAP
+        continue
+    fi
+
     if (( _CM_DISABLED )); then
-        # The first one will just be from interrupting `wait`, so don't print
-        if (( _CM_FIRST_DISABLE )); then
-            unset _CM_FIRST_DISABLE
-        else
-            info "Got a clipboard notification, but we are disabled, skipping"
-        fi
+        info "Got a clipboard notification, but we are disabled, skipping"
         continue
     fi
 

--- a/clipmenud
+++ b/clipmenud
@@ -56,6 +56,11 @@ get_first_line() {
 debug() { (( CM_DEBUG )) && printf '%s\n' "$@" >&2; }
 
 sig_disable() {
+    if (( _CM_DISABLED )); then
+        info "Received disable signal but we're already disabled, so doing nothing"
+        return
+    fi
+
     info "Received disable signal, suspending clipboard capture"
     _CM_DISABLED=1
     echo "disabled" > "$status_file"
@@ -63,7 +68,7 @@ sig_disable() {
 
 sig_enable() {
     if ! (( _CM_DISABLED )); then
-        info "Received enable signal but we're not disabled, so doing nothing"
+        info "Received enable signal but we're already enabled, so doing nothing"
         return
     fi
 


### PR DESCRIPTION
Hello,

While `clipmenud` is running, each time `clipctl enable` is executed another `clipnotify` job is spawn...

This bug is how I found out the need of #171 (fix to properly kill children jobs).

```
$ clipmenud &
...
$ ps -e | grep clipnotify
7382 pts/1   00:00:00 clipnotify
$ clipctl enable
...
$ ps -e | grep clipnotify
7382 pts/1   00:00:00 clipnotify
7395 pts/1   00:00:00 clipnotify
```

There's a problem in the main loop, which is easily fixable... When a signal is trapped, the `wait "$_CM_CLIPNOTIFY_PID"` breaks, and the loop restarts, spawning another `clipnotify` job because the previous one was not killed by `sig_enable`...

On the other hand, `sig_disable` kills the current `clipnotify` job before restarting the loop... We need to do the same for `sig_enable`.

Thanks.