### PR TITLE
allow fzf to preview content of a clip

### DIFF
--- a/clipmenu
+++ b/clipmenu
@@ -35,6 +35,19 @@ fi
 launcher_args=(-l "${CM_HISTLENGTH}")
 if [[ "$CM_LAUNCHER" == fzf ]]; then
     launcher_args=()
+    
+    # otherwise `cache_dir` won't be passed to `clip`
+    export cache_dir
+    
+    # this function gives the clip file matching selected line in fzf
+    # use it in fzf args, for instance: `--preview="cat \"$(clip {})\"`
+    clip() {
+        printf %s "${cache_dir}/$(cksum <<<"$1")"
+    }
+    
+    # the function has to be exported, otherwise it won't be available to fzf
+    # Cf. https://github.com/junegunn/fzf/issues/2762#issuecomment-1072108653
+    export -f clip
 fi
 
 # rofi supports dmenu-like arguments through the -dmenu flag. -p wastes space


### PR DESCRIPTION
A new function, `clip()`, is created if fzf is used to show clips. This function allows to preview the actual content of selected clip in fzf.
It can be used by passing the function as an argument to the preview command used in fzf, for instance:
```
fzf --preview="cat \"$(clip {})\""
```
I'm not sure about the first `export`, but it doesn't work without it.

First PR ever…
Thanks.