### PR TITLE
Improve test suite isolation, plus miscellaneous test suite changes

### DIFF
--- a/tests/fixtures/bin/clipmenu-launcher
+++ b/tests/fixtures/bin/clipmenu-launcher
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+SHIM_STDOUT="Selected text. (2 lines)" source clipmenu-test-shim "$@"

--- a/tests/fixtures/bin/clipmenu-perf
+++ b/tests/fixtures/bin/clipmenu-perf
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-exec 3>&2 2> >(tee "${log?}" |
+exec {BASH_XTRACEFD}> >(tee "${log?}" |
                  sed -u 's/^.*$/now/' |
                  date -f - +%s.%N > "${tim?}")
+
+export BASH_XTRACEFD
+
 set -x
 
 dmenu() { :; }

--- a/tests/fixtures/bin/clipmenu-perf
+++ b/tests/fixtures/bin/clipmenu-perf
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+exec 3>&2 2> >(tee "${log?}" |
+                 sed -u 's/^.*$/now/' |
+                 date -f - +%s.%N > "${tim?}")
+set -x
+
+dmenu() { :; }
+xsel() { :; }
+
+# shellcheck disable=SC1091
+source clipmenu "$@"

--- a/tests/fixtures/bin/clipmenu-test-shim
+++ b/tests/fixtures/bin/clipmenu-test-shim
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+printf '%s args:' "${0##*/}" >&2
+printf ' %q' "$@" >&2
+printf '\n' >&2
+
+i=0
+
+while IFS= read -r line; do
+    let i++
+    printf '%s line %d stdin: %s\n' "${0##*/}" "$i" "$line" >&2
+done
+
+if [[ -v SHIM_STDOUT ]]; then
+    printf '%s\n' "$SHIM_STDOUT"
+fi

--- a/tests/fixtures/bin/dmenu
+++ b/tests/fixtures/bin/dmenu
@@ -1,0 +1,1 @@
+clipmenu-launcher

--- a/tests/fixtures/bin/rofi
+++ b/tests/fixtures/bin/rofi
@@ -1,0 +1,1 @@
+clipmenu-launcher

--- a/tests/fixtures/bin/xclip
+++ b/tests/fixtures/bin/xclip
@@ -1,0 +1,1 @@
+clipmenu-test-shim

--- a/tests/fixtures/bin/xsel
+++ b/tests/fixtures/bin/xsel
@@ -1,0 +1,1 @@
+clipmenu-test-shim

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -11,6 +11,12 @@ toplevel() {
 }
 
 cleanup() {
+    local rc="$?"
+
+    if (( rc != 0 )); then
+        msg "ERROR: '${BASH_COMMAND}' exited with status '$rc'"
+    fi
+
     if command -v cleanup_pre &>/dev/null; then
         cleanup_pre
     fi

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -6,9 +6,27 @@ toplevel() {
     pwd -P
 }
 
+cleanup() {
+    if command -v cleanup_pre &>/dev/null; then
+        cleanup_pre
+    fi
+
+    if [[ -n "${tempdir:-}" ]] && [[ -d "$tempdir" ]]; then
+        # Try to use coreutils-specific args for safety; fall back to
+        # busybox-compatible args if necessary.
+        rm --one-file-system --preserve-root -rf "$tempdir" || rm -rf "$tempdir"
+    fi
+}
+
 toplevel="$(toplevel)"
 
 export PATH="${toplevel}${PATH:+:${PATH}}"
+
+tempdir="$(mktemp -d)"
+
+trap cleanup EXIT
+
+export CM_DIR="$tempdir"
 
 dir=$(clipctl cache-dir)
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -20,7 +20,7 @@ cleanup() {
 
 toplevel="$(toplevel)"
 
-export PATH="${toplevel}${PATH:+:${PATH}}"
+export PATH="${toplevel}/tests/fixtures/bin:${toplevel}${PATH:+:${PATH}}"
 
 tempdir="$(mktemp -d)"
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -28,6 +28,10 @@ cleanup() {
     fi
 }
 
+# Show contextual data in execution tracing (`set -x`) output
+PS4='+ ${BASH_SOURCE[0]##*/}@${LINENO}${FUNCNAME[0]:+${FUNCNAME[0]}()}: '
+export PS4
+
 toplevel="$(toplevel)"
 
 export PATH="${toplevel}/tests/fixtures/bin:${toplevel}${PATH:+:${PATH}}"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -40,7 +40,14 @@ tempdir="$(mktemp -d)"
 
 trap cleanup EXIT
 
-export CM_DIR="$tempdir"
+if (( NO_RECREATE )); then
+    dir=$(clipctl cache-dir)
+    CM_DIR="${dir}/tests/${BASH_SOURCE[1]##*/}"
+else
+    CM_DIR="$tempdir"
+fi
+
+export CM_DIR
 
 dir=$(clipctl cache-dir)
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+msg() {
+    printf '>>> %s\n' "$@" >&2
+}
+
 toplevel() {
     git rev-parse --show-toplevel 2>/dev/null && return
     readlink -f "${BASH_SOURCE[0]}/../.." 2>/dev/null && return

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+toplevel() {
+    git rev-parse --show-toplevel 2>/dev/null && return
+    readlink -f "${BASH_SOURCE[0]}/../.." 2>/dev/null && return
+    pwd -P
+}
+
+toplevel="$(toplevel)"
+
+export PATH="${toplevel}${PATH:+:${PATH}}"
+
+dir=$(clipctl cache-dir)
+
+# shellcheck disable=SC2034
+cache_file=$dir/line_cache

--- a/tests/test-clipmenu
+++ b/tests/test-clipmenu
@@ -15,44 +15,6 @@ cleanup_pre() {
     fi
 }
 
-cat - "${toplevel?}/clipmenu" > "${tempdir}/clipmenu" << 'EOF'
-#!/usr/bin/env bash
-
-shopt -s expand_aliases
-
-shim() {
-    printf '%s args:' "$1" >&2
-    printf ' %q' "${@:2}" >&2
-    printf '\n' >&2
-
-    i=0
-
-    while IFS= read -r line; do
-        let i++
-        printf '%s line %d stdin: %s\n' "$1" "$i" "$line" >&2
-    done
-
-    if [[ -v SHIM_STDOUT ]]; then
-        printf '%s\n' "$SHIM_STDOUT"
-    fi
-}
-
-# Cannot be an alias due to expansion order with $CM_LAUNCHER
-dmenu() {
-    SHIM_STDOUT="Selected text. (2 lines)" shim dmenu "$@"
-}
-
-rofi() {
-    SHIM_STDOUT="Selected text. (2 lines)" shim rofi "$@"
-}
-
-alias xsel='shim xsel'
-alias xclip='shim xclip'
-alias clipctl='./clipctl'
-EOF
-
-chmod a+x "${tempdir}/clipmenu"
-
 rm -rf "${dir?}"
 mkdir -p "$dir"
 
@@ -68,7 +30,7 @@ EOF
 
 ### TESTS ###
 
-"${tempdir}/clipmenu" --foo bar > "$temp" 2>&1
+clipmenu --foo bar > "$temp" 2>&1
 
 # Arguments are transparently passed to dmenu
 grep -Fxq 'dmenu args: -l 8 --foo bar' "$temp"
@@ -84,7 +46,7 @@ grep -Fxq 'xsel args: --logfile /dev/null -i --primary' "$temp"
 grep -Fxq 'xsel line 1 stdin: Selected text.' "$temp"
 grep -Fxq "xsel line 2 stdin: Yes, it's selected text." "$temp"
 
-CM_LAUNCHER=rofi "${tempdir}/clipmenu" --foo bar > "$temp" 2>&1
+CM_LAUNCHER=rofi clipmenu --foo bar > "$temp" 2>&1
 
 # We have a special case to add -dmenu for rofi
 grep -Fxq 'rofi args: -l 8 -dmenu -p clipmenu --foo bar' "$temp"

--- a/tests/test-clipmenu
+++ b/tests/test-clipmenu
@@ -7,8 +7,15 @@ set -o pipefail
 # shellcheck disable=SC1091
 source "${BASH_SOURCE[0]%/*}/setup.sh"
 
+temp="${tempdir?}/out"
 
-cat - "${toplevel?}/clipmenu" > /tmp/clipmenu << 'EOF'
+cleanup_pre() {
+    if [[ -n "${temp:-}" ]] && [[ -f "$temp" ]]; then
+        cat "$temp"
+    fi
+}
+
+cat - "${toplevel?}/clipmenu" > "${tempdir}/clipmenu" << 'EOF'
 #!/usr/bin/env bash
 
 shopt -s expand_aliases
@@ -44,7 +51,7 @@ alias xclip='shim xclip'
 alias clipctl='./clipctl'
 EOF
 
-chmod a+x /tmp/clipmenu
+chmod a+x "${tempdir}/clipmenu"
 
 rm -rf "${dir?}"
 mkdir -p "$dir"
@@ -61,11 +68,7 @@ EOF
 
 ### TESTS ###
 
-temp=$(mktemp)
-
-trap 'cat "$temp"' EXIT
-
-/tmp/clipmenu --foo bar > "$temp" 2>&1
+"${tempdir}/clipmenu" --foo bar > "$temp" 2>&1
 
 # Arguments are transparently passed to dmenu
 grep -Fxq 'dmenu args: -l 8 --foo bar' "$temp"
@@ -81,7 +84,7 @@ grep -Fxq 'xsel args: --logfile /dev/null -i --primary' "$temp"
 grep -Fxq 'xsel line 1 stdin: Selected text.' "$temp"
 grep -Fxq "xsel line 2 stdin: Yes, it's selected text." "$temp"
 
-CM_LAUNCHER=rofi /tmp/clipmenu --foo bar > "$temp" 2>&1
+CM_LAUNCHER=rofi "${tempdir}/clipmenu" --foo bar > "$temp" 2>&1
 
 # We have a special case to add -dmenu for rofi
 grep -Fxq 'rofi args: -l 8 -dmenu -p clipmenu --foo bar' "$temp"

--- a/tests/test-clipmenu
+++ b/tests/test-clipmenu
@@ -4,17 +4,11 @@ set -x
 set -e
 set -o pipefail
 
-dir=$(./clipctl cache-dir)
-cache_file=$dir/line_cache
+# shellcheck disable=SC1091
+source "${BASH_SOURCE[0]%/*}/setup.sh"
 
-if [[ $0 == /* ]]; then
-    location=${0%/*}
-else
-    location=$PWD/${0#./}
-    location=${location%/*}
-fi
 
-cat - "$location/../clipmenu" > /tmp/clipmenu << 'EOF'
+cat - "${toplevel?}/clipmenu" > /tmp/clipmenu << 'EOF'
 #!/usr/bin/env bash
 
 shopt -s expand_aliases
@@ -52,10 +46,10 @@ EOF
 
 chmod a+x /tmp/clipmenu
 
-rm -rf "$dir"
+rm -rf "${dir?}"
 mkdir -p "$dir"
 
-cat > "$cache_file" << 'EOF'
+cat > "${cache_file?}" << 'EOF'
 1234 Selected text. (2 lines)
 1235 Selected text 2. (2 lines)
 EOF

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -9,11 +9,23 @@ num_files=1500
 
 if ! (( NO_RECREATE )); then
     rm -rf "${dir?}"
+fi
+
+if ! [[ -d "${dir?}" ]]; then
     mkdir -p "$dir"
+fi
 
-    msg "Writing $num_files clipboard files"
+num_need="$num_files"
+for child in "$dir"/*; do
+    if [[ -f "$child" ]] && ! [[ "$child" -ef "${cache_file?}" ]]; then
+        (( num_need-- ))
+    fi
+done
 
-    for (( i = 0; i <= num_files; i++ )); do
+if (( num_need > 0 )); then
+    msg "Writing $num_need clipboard files"
+
+    for (( i = 0; i <= num_need; i++ )); do
         (( i % 100 )) || printf '%s... ' "$i"
 
         line_len=$(( (RANDOM % 10000) + 1 ))

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -4,8 +4,8 @@ msg() {
     printf '>>> %s\n' "$@" >&2
 }
 
-dir=$(clipctl cache-dir)
-cache_file=$dir/line_cache
+# shellcheck disable=SC1091
+source "${BASH_SOURCE[0]%/*}/setup.sh"
 
 log=$(mktemp)
 tim=$(mktemp)
@@ -14,16 +14,9 @@ num_files=1500
 
 trap 'rm -f -- "$log" "$tim" "$clipmenu_shim"' EXIT
 
-if [[ $0 == /* ]]; then
-    location=${0%/*}
-else
-    location=$PWD/${0#./}
-    location=${location%/*}
-fi
-
 msg 'Setting up edited clipmenu'
 
-cat - "$location/../clipmenu" > /tmp/clipmenu << EOF
+cat - "${toplevel?}/clipmenu" > /tmp/clipmenu << EOF
 #!/usr/bin/env bash
 
 exec 3>&2 2> >(tee "$log" |
@@ -39,7 +32,7 @@ EOF
 chmod a+x /tmp/clipmenu
 
 if ! (( NO_RECREATE )); then
-    rm -rf "$dir"
+    rm -rf "${dir?}"
     mkdir -p "$dir"
 
     msg "Writing $num_files clipboard files"
@@ -56,7 +49,7 @@ if ! (( NO_RECREATE )); then
         )
         read -r first_line_raw <<< "$data"
         printf -v first_line '%s (%s lines)\n' "$first_line_raw" "$num_lines"
-        printf '%d %s' "$i" "$first_line" >> "$cache_file"
+        printf '%d %s' "$i" "$first_line" >> "${cache_file?}"
         fn=$dir/$(cksum <<< "$first_line")
         printf '%s' "$data" > "$fn"
     done

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -11,23 +11,6 @@ log="${tempdir?}/log"
 tim="${tempdir}/tim"
 num_files=1500
 
-msg 'Setting up edited clipmenu'
-
-cat - "${toplevel?}/clipmenu" > "${tempdir}/clipmenu" << EOF
-#!/usr/bin/env bash
-
-exec 3>&2 2> >(tee "$log" |
-                 sed -u 's/^.*$/now/' |
-                 date -f - +%s.%N > "$tim")
-set -x
-
-dmenu() { :; }
-xsel() { :; }
-
-EOF
-
-chmod a+x "${tempdir}/clipmenu"
-
 if ! (( NO_RECREATE )); then
     rm -rf "${dir?}"
     mkdir -p "$dir"
@@ -56,9 +39,9 @@ else
     msg 'Not nuking/creating new clipmenu files'
 fi
 
-msg 'Running modified clipmenu'
+msg 'Running clipmenu performance-testing wrapper'
 
-time "${tempdir}/clipmenu"
+time log="$log" tim="$tim" clipmenu-perf
 
 (( TIME_ONLY )) && exit 0
 

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-msg() {
-    printf '>>> %s\n' "$@" >&2
-}
-
 # shellcheck disable=SC1091
 source "${BASH_SOURCE[0]%/*}/setup.sh"
 

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -7,16 +7,13 @@ msg() {
 # shellcheck disable=SC1091
 source "${BASH_SOURCE[0]%/*}/setup.sh"
 
-log=$(mktemp)
-tim=$(mktemp)
-clipmenu_shim=$(mktemp)
+log="${tempdir?}/log"
+tim="${tempdir}/tim"
 num_files=1500
-
-trap 'rm -f -- "$log" "$tim" "$clipmenu_shim"' EXIT
 
 msg 'Setting up edited clipmenu'
 
-cat - "${toplevel?}/clipmenu" > /tmp/clipmenu << EOF
+cat - "${toplevel?}/clipmenu" > "${tempdir}/clipmenu" << EOF
 #!/usr/bin/env bash
 
 exec 3>&2 2> >(tee "$log" |
@@ -29,7 +26,7 @@ xsel() { :; }
 
 EOF
 
-chmod a+x /tmp/clipmenu
+chmod a+x "${tempdir}/clipmenu"
 
 if ! (( NO_RECREATE )); then
     rm -rf "${dir?}"
@@ -61,7 +58,7 @@ fi
 
 msg 'Running modified clipmenu'
 
-time /tmp/clipmenu
+time "${tempdir}/clipmenu"
 
 (( TIME_ONLY )) && exit 0
 


### PR DESCRIPTION
First, thanks for `clipmenu` -- it has upped my clipboard game significantly :)

While working on a different PR, I ran the `clipmenu` test suite and was surprised to find that it clobbered my clipboard cache.  This PR is my attempt to isolate the test suite from the user's existing state; the PR also introduces some miscellaneous additional changes.

Summary of changes:

1. Introduce a test fixtures hierarchy.  The fixtures directory contains a `bin` path with executables that replace the executables previously dynamically generated in `tests/test-clipmenu` and `tests/test-perf`.
2. Prepend the `test/fixtures/bin` directory and the `clipmenu` repository toplevel directory to `PATH`.  This makes it possible to run (say) `clipctl cache-dir` and be confident that the selected `clipctl` executable is `<toplevel>/clipctl`.
3. Put all generated assets (including the clipboard cache file) into a shared temporary directory (`tempdir=$(mktemp -d)`).  This simplifies end-of-test filesystem cleanup (just recursively remove `tempdir`).
4. Add a `cleanup` function that runs as a `trap` on the `EXIT` pseudo-signal.  This function recursively removes the above-mentioned `tempdir`, and also provides a `cleanup_pre` hook for running code prior to removing the temporary directory hierarchy.  `tests/test-clipmenu` uses `cleanup_pre` to print the contents of the temporary file used for capturing the mocked-up launchers' output.
5. Consolidated common test setup (including some of the things mentioned above) into the file `tests/setup.sh`, and source this file from `tests/test-clipmenu` and `tests/test-perf`.
6. In `tests/test-perf`, ensure that we always generate 1500 clipboard files.  Previously, if `NO_RECREATE` was in effect and a previous test run generated fewer that 1500 clipboard files (say, the test run was interrupted during the generation stage), subsequent runs with `NO_RECREATE` in effect would not generate the remaining needed files.
7. Print a  diagnostic message in the `cleanup` trap function when a test script failed.  The diagnostic message includes the command that failed, to aid in debugging.
8. Use a dynamically-assigned `BASH_XTRACEFD` in the `test/fixtures/bin/clipmenu-perf` wrapper rather than using the default `stderr` file descriptor.
9. Define a `PS4` that results in `xtrace` displaying additional execution context -- filename, line number, and (if applicable) shell function.

Thanks again for `clipmenu`, and thanks in advance for your consideration.