### PR TITLE
rofi script mode options

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ Note that if you:
    basename is something other than `dmenu`, `fzf`, or `rofi`,
 
 then clipmenu assumes `CM_LAUNCHER` is dmenu-compatible; that is, clipmenu
-will invoke the launcher with dmenu-appropriate arguments.
+will invoke the launcher with dmenu-appropriate arguments -- **unless**
+clipmenu detects that it is running under [rofi's script mode][], in which case
+it will follow the script mode protocol.
 
 ## Using a custom launcher
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ clipmenu will invoke rofi like so:
 
     rofi -dmenu -p clipmenu -l 12 -i -fn Terminus:size=8 -nb '#002b36' -nf '#839496' -sb '#073642' -sf '#93a1a1'
 
+## Specifying a launcher
+
+To tell clipmenu which launcher to use, define `CM_LAUNCHER` as follows:
+
+    # clipmenu uses the command named `mylauncher`
+    CM_LAUNCHER=mylauncher
+
+Or:
+
+    # clipmenu uses the specified launcher path
+    CM_LAUNCHER=/path/to/mylauncher
+
 # Installation
 
 Several distributions, including Arch and Nix, provide clipmenu as an official

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ configurations that are known to work:
 - `dmenu` (the default)
 - `fzf`
 - `rofi`
-- `rofi-script`, for [rofi's script
-  mode](https://github.com/davatorium/rofi-scripts/tree/master/mode-scripts)
+- `rofi-script`, for [rofi's script mode][]
 
 ## The clipmenu launcher protocol
 
@@ -106,6 +105,38 @@ Or:
     # clipmenu uses the specified launcher path
     CM_LAUNCHER=/path/to/mylauncher
 
+## Specifying the launcher type
+
+clipmenu supports [several launchers](#supported-launchers), primarily by
+passing appropriate command-line arguments to the command specified in the
+`CM_LAUNCHER` environment variable (or `dmenu` if `CM_LAUNCHER` is unset).
+
+By default, clipmenu detects the launcher type by inspecting the basename of
+the launcher command.  That is, when the basename of `CM_LAUNCHER` is `dmenu`,
+clipmenu will call the launcher with `dmenu`-appropriate arguments, when the
+basename is `rofi`, clipmenu will call the launcher with `rofi`-appropriate
+arguments, and so on.
+
+To override this detection logic, you can define the `CM_LAUNCHER_TYPE`
+environment variable.  Supported values are:
+
+1. `dmenu` - pass dmenu-appropriate arguments
+2. `fzf` - pass fzf-appropriate arguments
+3. `rofi` - pass rofi-appropriate arguments
+4. `rofi-script` - follow [rofi's script mode][] protocol
+
+Note that if you:
+
+1. Set `CM_LAUNCHER_TYPE` to any value other than the four listed above,
+
+**or**
+
+2. Leave `CM_LAUNCHER_TYPE` unset and set `CM_LAUNCHER` to a value whose
+   basename is something other than `dmenu`, `fzf`, or `rofi`,
+
+then clipmenu assumes `CM_LAUNCHER` is dmenu-compatible; that is, clipmenu
+will invoke the launcher with dmenu-appropriate arguments.
+
 # Installation
 
 Several distributions, including Arch and Nix, provide clipmenu as an official
@@ -140,3 +171,4 @@ it should be fairly self-explanatory. However, at the most basic level:
 [dmenu]: http://tools.suckless.org/dmenu/
 [rofi]: https://github.com/DaveDavenport/Rofi
 [xsel]: http://www.vergenet.net/~conrad/software/xsel/
+[rofi's script mode]: https://github.com/davatorium/rofi-scripts/tree/master/mode-scripts

--- a/README.md
+++ b/README.md
@@ -65,14 +65,18 @@ configurations that are known to work:
 - `rofi`
 - `rofi-script`, for [rofi's script mode][]
 
+Additionally, clipmenu supports a [custom launcher mode][] for implementing
+custom launcher behavior.
+
 ## The clipmenu launcher protocol
 
-The clipmenu launcher protocol consists of two interprocess communication
+The clipmenu launcher protocol consists of three interprocess communication
 methods.  clipmenu calls the launcher command as follows:
 
 1. With its standard input set to a newline-separated stream of available
-   clipboard selections, and
-2. With a potentially-empty list of command line arguments.
+   clipboard selections,
+2. With a potentially-empty list of command line arguments, and
+3. With certain environment variables set (in [custom launcher mode][]).
 
 The command line arguments convention is:
 
@@ -124,10 +128,11 @@ environment variable.  Supported values are:
 2. `fzf` - pass fzf-appropriate arguments
 3. `rofi` - pass rofi-appropriate arguments
 4. `rofi-script` - follow [rofi's script mode][] protocol
+5. `custom` - see the section on [custom launcher mode][]
 
 Note that if you:
 
-1. Set `CM_LAUNCHER_TYPE` to any value other than the four listed above,
+1. Set `CM_LAUNCHER_TYPE` to any value other than the five listed above,
 
 **or**
 
@@ -136,6 +141,29 @@ Note that if you:
 
 then clipmenu assumes `CM_LAUNCHER` is dmenu-compatible; that is, clipmenu
 will invoke the launcher with dmenu-appropriate arguments.
+
+## Using a custom launcher
+
+In custom laucher mode, clipmenu follows the typical [launcher
+protocol](#the-clipmenu-launcher-protocol) and also sets the following
+environment variables:
+
+1. `CM_DMENU_ARGS` - contains shell-quoted arguments appropriate to pass to
+   `dmenu`
+2. `CM_FZF_ARGS` - contains shell-quoted arguments appropriate to pass to
+   `fzf`
+3. `CM_ROFI_ARGS` - contains shell-quoted arguments appropriate to pass to
+   `rofi`
+
+You can use this information for purposes like selecting a "real" launcher
+implementation based upon whether you've started clipmenu from a terminal or
+not:
+
+    if detect-terminal-somehow; then
+        exec fzf $CM_FZF_ARGS "$@"
+    else
+        exec dmenu $CM_DMENU_ARGS "$@"
+    fi
 
 # Installation
 
@@ -172,3 +200,4 @@ it should be fairly self-explanatory. However, at the most basic level:
 [rofi]: https://github.com/DaveDavenport/Rofi
 [xsel]: http://www.vergenet.net/~conrad/software/xsel/
 [rofi's script mode]: https://github.com/davatorium/rofi-scripts/tree/master/mode-scripts
+[custom launcher mode]: #using-a-custom-launcher

--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ configurations that are known to work:
 - `rofi-script`, for [rofi's script
   mode](https://github.com/davatorium/rofi-scripts/tree/master/mode-scripts)
 
+## The clipmenu launcher protocol
+
+The clipmenu launcher protocol consists of two interprocess communication
+methods.  clipmenu calls the launcher command as follows:
+
+1. With its standard input set to a newline-separated stream of available
+   clipboard selections, and
+2. With a potentially-empty list of command line arguments.
+
+The command line arguments convention is:
+
+    <launcher-command> [<launcher-specific-arguments...>] [<pass-through-arguments...>]
+
+Where:
+
+1. `<launcher-specific-arguments...>` is a potentially-empty list of arguments
+   specific to [the selected launcher](#specifying-a-launcher), and
+2. `<pass-through-arguments...>` is the potentially-empty list of arguments
+   provided to [clipmenu itself](#clipmenu).
+
+For instance, when invoked like so:
+
+    CM_LAUNCHER=rofi CM_HISTLENGTH=12 clipmenu -i -fn Terminus:size=8 -nb '#002b36' -nf '#839496' -sb '#073642' -sf '#93a1a1'
+
+clipmenu will invoke rofi like so:
+
+    rofi -dmenu -p clipmenu -l 12 -i -fn Terminus:size=8 -nb '#002b36' -nf '#839496' -sb '#073642' -sf '#93a1a1'
+
 # Installation
 
 Several distributions, including Arch and Nix, provide clipmenu as an official

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![Tests](https://img.shields.io/travis/cdown/clipmenu/develop.svg)](https://travis-ci.org/cdown/clipmenu)
 
-clipmenu is a simple clipboard manager using [dmenu][] (or [rofi][] with
-`CM_LAUNCHER=rofi`) and [xsel][].
+clipmenu is a simple clipboard manager using [dmenu][]* and [xsel][].
+
+*Or another [supported launcher](#supported-launchers)
 
 # Demo
 
@@ -26,9 +27,10 @@ clipmenud:
 
 You may wish to bind a shortcut in your window manager to launch `clipmenu`.
 
-All args passed to clipmenu are transparently dispatched to dmenu. That is, if
-you usually call dmenu with args to set colours and other properties, you can
-invoke clipmenu in exactly the same way to get the same effect, like so:
+All args passed to clipmenu are transparently dispatched to dmenu (or another
+[supported launcher](#supported-launchers)). That is, if you usually call dmenu
+with args to set colours and other properties, you can invoke clipmenu in
+exactly the same way to get the same effect, like so:
 
     clipmenu -i -fn Terminus:size=8 -nb '#002b36' -nf '#839496' -sb '#073642' -sf '#93a1a1'
 

--- a/clipmenu
+++ b/clipmenu
@@ -21,7 +21,7 @@ Environment variables:
 - $CM_DIR: specify the base directory to store the cache dir in (default: $XDG_RUNTIME_DIR, $TMPDIR, or /tmp)
 - $CM_HISTLENGTH: specify the number of lines to show in dmenu/rofi (default: 8)
 - $CM_LAUNCHER: specify the name or path of a supported launcher (default: dmenu)
-- $CM_LAUNCHER_TYPE: the type of launcher implementation (supported: dmenu, fzf, rofi, rofi-script; default: dmenu)
+- $CM_LAUNCHER_TYPE: the type of launcher implementation (supported: dmenu, fzf, custom, rofi, rofi-script; default: dmenu)
 - $CM_OUTPUT_CLIP: if set, output clip selectikn to stdout
 EOF
     exit 0
@@ -56,6 +56,19 @@ invoke_rofi_launcher() {
     run_launcher "${rofi_launcher_args[@]}" "$@"
 }
 
+invoke_custom_launcher() {
+    local dmenu_args fzf_args rofi_args
+
+    printf -v dmenu_args '%q ' "${dmenu_launcher_args[@]}"
+    printf -v fzf_args '%q ' "${fzf_launcher_args[@]}"
+    printf -v rofi_args '%q ' "${rofi_launcher_args[@]}"
+
+    CM_DMENU_ARGS="$dmenu_args" \
+        CM_FZF_ARGS="$fzf_args" \
+        CM_ROFI_ARGS="$rofi_args" \
+        run_launcher "$@"
+}
+
 invoke_launcher() {
     "invoke_${CM_LAUNCHER_TYPE?internal error: CM_LAUNCHER_TYPE must be defined}_launcher" "$@"
 }
@@ -67,6 +80,12 @@ list_clips() {
 case "${CM_LAUNCHER_TYPE:-}" in
     dmenu|fzf|rofi|rofi-script)
         # NOP
+        ;;
+    custom)
+        if ! [[ -v CM_LAUNCHER ]]; then
+            printf 1>&2 -- "CM_LAUNCHER must be set when using CM_LAUNCHER_TYPE 'custom'\\n"
+            exit 2
+        fi
         ;;
     '')
         CM_LAUNCHER_TYPE="${CM_LAUNCHER##*/}"

--- a/clipmenu
+++ b/clipmenu
@@ -20,7 +20,7 @@ Environment variables:
 
 - $CM_DIR: specify the base directory to store the cache dir in (default: $XDG_RUNTIME_DIR, $TMPDIR, or /tmp)
 - $CM_HISTLENGTH: specify the number of lines to show in dmenu/rofi (default: 8)
-- $CM_LAUNCHER: specify a dmenu-compatible launcher (default: dmenu)
+- $CM_LAUNCHER: specify the name or path of a dmenu-compatible launcher (default: dmenu)
 - $CM_OUTPUT_CLIP: if set, output clip selection to stdout
 EOF
     exit 0
@@ -32,18 +32,47 @@ if ! [[ -f "$cache_file" ]]; then
 fi
 
 # Blacklist of non-dmenu launchers
-launcher_args=(-l "${CM_HISTLENGTH}")
-if [[ "$CM_LAUNCHER" == fzf ]]; then
-    launcher_args=()
-fi
+dmenu_launcher_args=(-l "${CM_HISTLENGTH}")
+fzf_launcher_args=()
 
 # rofi supports dmenu-like arguments through the -dmenu flag. -p wastes space
 # in real dmenu, but rofi shows "dmenu:" anyway, so pass it here only.
-[[ "$CM_LAUNCHER" == rofi ]] && set -- -dmenu -p clipmenu "$@"
+rofi_launcher_args=(-dmenu -p clipmenu "${dmenu_launcher_args[@]}")
+
+run_launcher() {
+    "${CM_LAUNCHER?internal error: CM_LAUNCHER must be defined}" "$@"
+}
+
+invoke_dmenu_launcher() {
+    run_launcher "${dmenu_launcher_args[@]}" "$@"
+}
+
+invoke_fzf_launcher() {
+    run_launcher "${fzf_launcher_args[@]}" "$@"
+}
+
+invoke_rofi_launcher() {
+    run_launcher "${rofi_launcher_args[@]}" "$@"
+}
+
+invoke_launcher() {
+    "invoke_${CM_LAUNCHER_TYPE?internal error: CM_LAUNCHER_TYPE must be defined}_launcher" "$@"
+}
 
 list_clips() {
     LC_ALL=C sort -rnk 1 < "$cache_file" | cut -d' ' -f2- | awk '!seen[$0]++'
 }
+
+CM_LAUNCHER_TYPE="${CM_LAUNCHER##*/}"
+
+case "$CM_LAUNCHER_TYPE" in
+    dmenu|fzf|rofi)
+        # NOP
+        ;;
+    *)
+        CM_LAUNCHER_TYPE=dmenu
+        ;;
+esac
 
 if [[ "$CM_LAUNCHER" == rofi-script ]]; then
     if (( $# )); then
@@ -53,7 +82,7 @@ if [[ "$CM_LAUNCHER" == rofi-script ]]; then
         exit
     fi
 else
-    chosen_line=$(list_clips | "$CM_LAUNCHER" "${launcher_args[@]}" "$@")
+    chosen_line=$(list_clips | invoke_launcher "$@")
     launcher_exit=$?
 fi
 

--- a/clipmenu
+++ b/clipmenu
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-: "${CM_LAUNCHER=dmenu}"
 : "${CM_HISTLENGTH=8}"
 
 shopt -s nullglob
@@ -87,23 +86,39 @@ case "${CM_LAUNCHER_TYPE:-}" in
             exit 2
         fi
         ;;
-    '')
-        CM_LAUNCHER_TYPE="${CM_LAUNCHER##*/}"
+    *)
+        if [[ -v CM_LAUNCHER ]]; then
+            launcher_type="${CM_LAUNCHER##*/}"
+        fi
 
-        case "$CM_LAUNCHER_TYPE" in
+        case "${launcher_type:-}" in
             dmenu|fzf|rofi)
                 # NOP
                 ;;
             *)
-                CM_LAUNCHER_TYPE=dmenu
+                if [[ -v ROFI_RETV ]]; then
+                    launcher_type=rofi-script
+                else
+                    launcher_type=dmenu
+                fi
                 ;;
         esac
-        ;;
-    *)
-        printf 1>&2 -- "Unrecognized CM_LAUNCHER_TYPE '%s'; assuming 'dmenu'-type launcher.\\n" "$CM_LAUNCHER_TYPE"
-        CM_LAUNCHER_TYPE=dmenu
+
+        if [[ "$launcher_type" != "${CM_LAUNCHER_TYPE:-}" ]]; then
+            if [[ -v CM_LAUNCHER_TYPE ]]; then
+                printf 1>&2 -- "Unrecognized CM_LAUNCHER_TYPE '%s'; assuming '%s'-type launcher.\\n" \
+                    "$CM_LAUNCHER_TYPE" "$launcher_type"
+            fi
+
+            CM_LAUNCHER_TYPE="$launcher_type"
+        fi
         ;;
 esac
+
+# If we've gotten this far and CM_LAUNCHER is unset, then we know that
+# CM_LAUNCHER_TYPE contains one of "dmenu", "fzf", "rofi", or "rofi-script",
+# which is also a safe and appropriate value for CM_LAUNCHER.
+: "${CM_LAUNCHER="$CM_LAUNCHER_TYPE"}"
 
 if [[ "$CM_LAUNCHER_TYPE" == rofi-script ]]; then
     if (( $# )); then

--- a/clipmenu
+++ b/clipmenu
@@ -20,8 +20,9 @@ Environment variables:
 
 - $CM_DIR: specify the base directory to store the cache dir in (default: $XDG_RUNTIME_DIR, $TMPDIR, or /tmp)
 - $CM_HISTLENGTH: specify the number of lines to show in dmenu/rofi (default: 8)
-- $CM_LAUNCHER: specify the name or path of a dmenu-compatible launcher (default: dmenu)
-- $CM_OUTPUT_CLIP: if set, output clip selection to stdout
+- $CM_LAUNCHER: specify the name or path of a supported launcher (default: dmenu)
+- $CM_LAUNCHER_TYPE: the type of launcher implementation (supported: dmenu, fzf, rofi, rofi-script; default: dmenu)
+- $CM_OUTPUT_CLIP: if set, output clip selectikn to stdout
 EOF
     exit 0
 fi
@@ -63,18 +64,29 @@ list_clips() {
     LC_ALL=C sort -rnk 1 < "$cache_file" | cut -d' ' -f2- | awk '!seen[$0]++'
 }
 
-CM_LAUNCHER_TYPE="${CM_LAUNCHER##*/}"
-
-case "$CM_LAUNCHER_TYPE" in
-    dmenu|fzf|rofi)
+case "${CM_LAUNCHER_TYPE:-}" in
+    dmenu|fzf|rofi|rofi-script)
         # NOP
         ;;
+    '')
+        CM_LAUNCHER_TYPE="${CM_LAUNCHER##*/}"
+
+        case "$CM_LAUNCHER_TYPE" in
+            dmenu|fzf|rofi)
+                # NOP
+                ;;
+            *)
+                CM_LAUNCHER_TYPE=dmenu
+                ;;
+        esac
+        ;;
     *)
+        printf 1>&2 -- "Unrecognized CM_LAUNCHER_TYPE '%s'; assuming 'dmenu'-type launcher.\\n" "$CM_LAUNCHER_TYPE"
         CM_LAUNCHER_TYPE=dmenu
         ;;
 esac
 
-if [[ "$CM_LAUNCHER" == rofi-script ]]; then
+if [[ "$CM_LAUNCHER_TYPE" == rofi-script ]]; then
     if (( $# )); then
         chosen_line="${!#}"
     else

--- a/clipmenu
+++ b/clipmenu
@@ -120,7 +120,20 @@ esac
 # which is also a safe and appropriate value for CM_LAUNCHER.
 : "${CM_LAUNCHER="$CM_LAUNCHER_TYPE"}"
 
+# https://github.com/davatorium/rofi/blob/38c102d63b51488299fad4189beb5bbf3e7ca5ae/doc/rofi-script.5.markdown
 if [[ "$CM_LAUNCHER_TYPE" == rofi-script ]]; then
+    # See this for how to to set rofi options while in script mode:
+    # https://github.com/davatorium/rofi/blob/38c102d63b51488299fad4189beb5bbf3e7ca5ae/doc/rofi-script.5.markdown#passing-mode-options
+
+    # Set the rofi prompt to "clipmenu"
+    printf -- '\0prompt\x1fclipmenu\n'
+
+    # Disable custom input; user may only select a listed entry -- since we
+    # list all available clipboard selections, a query result that doesn't
+    # match anything will cause this script to exit (a) with a nonzero value
+    # and (b) without putting anything into the selection buffers.
+    printf -- '\0no-custom\x1ftrue\n'
+
     if (( $# )); then
         chosen_line="${!#}"
     else

--- a/tests/fixtures/bin/clipmenu-launcher
+++ b/tests/fixtures/bin/clipmenu-launcher
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+SHIM_STDOUT="Selected text. (2 lines)" source clipmenu-test-shim "$@"

--- a/tests/fixtures/bin/clipmenu-perf
+++ b/tests/fixtures/bin/clipmenu-perf
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-exec 3>&2 2> >(tee "${log?}" |
+exec {BASH_XTRACEFD}> >(tee "${log?}" |
                  sed -u 's/^.*$/now/' |
                  date -f - +%s.%N > "${tim?}")
+
+export BASH_XTRACEFD
+
 set -x
 
 dmenu() { :; }

--- a/tests/fixtures/bin/clipmenu-perf
+++ b/tests/fixtures/bin/clipmenu-perf
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+exec 3>&2 2> >(tee "${log?}" |
+                 sed -u 's/^.*$/now/' |
+                 date -f - +%s.%N > "${tim?}")
+set -x
+
+dmenu() { :; }
+xsel() { :; }
+
+# shellcheck disable=SC1091
+source clipmenu "$@"

--- a/tests/fixtures/bin/clipmenu-test-shim
+++ b/tests/fixtures/bin/clipmenu-test-shim
@@ -7,7 +7,7 @@ printf '\n' >&2
 i=0
 
 while IFS= read -r line; do
-    let i++
+    i="$(( i + 1 ))"
     printf '%s line %d stdin: %s\n' "${0##*/}" "$i" "$line" >&2
 done
 

--- a/tests/fixtures/bin/clipmenu-test-shim
+++ b/tests/fixtures/bin/clipmenu-test-shim
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+printf '%s args:' "${0##*/}" >&2
+printf ' %q' "$@" >&2
+printf '\n' >&2
+
+i=0
+
+while IFS= read -r line; do
+    let i++
+    printf '%s line %d stdin: %s\n' "${0##*/}" "$i" "$line" >&2
+done
+
+if [[ -v SHIM_STDOUT ]]; then
+    printf '%s\n' "$SHIM_STDOUT"
+fi

--- a/tests/fixtures/bin/custom
+++ b/tests/fixtures/bin/custom
@@ -1,0 +1,1 @@
+clipmenu-launcher

--- a/tests/fixtures/bin/dmenu
+++ b/tests/fixtures/bin/dmenu
@@ -1,0 +1,1 @@
+clipmenu-launcher

--- a/tests/fixtures/bin/mylauncher
+++ b/tests/fixtures/bin/mylauncher
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# `CM_DMENU_ARGS` is shell-quoted.
+# shellcheck disable=SC1091,SC2086
+source dmenu ${CM_DMENU_ARGS:-} "$@"

--- a/tests/fixtures/bin/rofi
+++ b/tests/fixtures/bin/rofi
@@ -1,0 +1,1 @@
+clipmenu-launcher

--- a/tests/fixtures/bin/rofi-script
+++ b/tests/fixtures/bin/rofi-script
@@ -1,0 +1,1 @@
+clipmenu-launcher

--- a/tests/fixtures/bin/xclip
+++ b/tests/fixtures/bin/xclip
@@ -1,0 +1,1 @@
+clipmenu-test-shim

--- a/tests/fixtures/bin/xsel
+++ b/tests/fixtures/bin/xsel
@@ -1,0 +1,1 @@
+clipmenu-test-shim

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -11,6 +11,12 @@ toplevel() {
 }
 
 cleanup() {
+    local rc="$?"
+
+    if (( rc != 0 )); then
+        msg "ERROR: '${BASH_COMMAND}' exited with status '$rc'"
+    fi
+
     if command -v cleanup_pre &>/dev/null; then
         cleanup_pre
     fi

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -6,9 +6,27 @@ toplevel() {
     pwd -P
 }
 
+cleanup() {
+    if command -v cleanup_pre &>/dev/null; then
+        cleanup_pre
+    fi
+
+    if [[ -n "${tempdir:-}" ]] && [[ -d "$tempdir" ]]; then
+        # Try to use coreutils-specific args for safety; fall back to
+        # busybox-compatible args if necessary.
+        rm --one-file-system --preserve-root -rf "$tempdir" || rm -rf "$tempdir"
+    fi
+}
+
 toplevel="$(toplevel)"
 
 export PATH="${toplevel}${PATH:+:${PATH}}"
+
+tempdir="$(mktemp -d)"
+
+trap cleanup EXIT
+
+export CM_DIR="$tempdir"
 
 dir=$(clipctl cache-dir)
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -20,7 +20,7 @@ cleanup() {
 
 toplevel="$(toplevel)"
 
-export PATH="${toplevel}${PATH:+:${PATH}}"
+export PATH="${toplevel}/tests/fixtures/bin:${toplevel}${PATH:+:${PATH}}"
 
 tempdir="$(mktemp -d)"
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -28,6 +28,10 @@ cleanup() {
     fi
 }
 
+# Show contextual data in execution tracing (`set -x`) output
+PS4='+ ${BASH_SOURCE[0]##*/}@${LINENO}${FUNCNAME[0]:+${FUNCNAME[0]}()}: '
+export PS4
+
 toplevel="$(toplevel)"
 
 export PATH="${toplevel}/tests/fixtures/bin:${toplevel}${PATH:+:${PATH}}"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -40,7 +40,14 @@ tempdir="$(mktemp -d)"
 
 trap cleanup EXIT
 
-export CM_DIR="$tempdir"
+if (( NO_RECREATE )); then
+    dir=$(clipctl cache-dir)
+    CM_DIR="${dir}/tests/${BASH_SOURCE[1]##*/}"
+else
+    CM_DIR="$tempdir"
+fi
+
+export CM_DIR
 
 dir=$(clipctl cache-dir)
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+msg() {
+    printf '>>> %s\n' "$@" >&2
+}
+
 toplevel() {
     git rev-parse --show-toplevel 2>/dev/null && return
     readlink -f "${BASH_SOURCE[0]}/../.." 2>/dev/null && return

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+toplevel() {
+    git rev-parse --show-toplevel 2>/dev/null && return
+    readlink -f "${BASH_SOURCE[0]}/../.." 2>/dev/null && return
+    pwd -P
+}
+
+toplevel="$(toplevel)"
+
+export PATH="${toplevel}${PATH:+:${PATH}}"
+
+dir=$(clipctl cache-dir)
+
+# shellcheck disable=SC2034
+cache_file=$dir/line_cache

--- a/tests/test-clipmenu
+++ b/tests/test-clipmenu
@@ -50,3 +50,28 @@ CM_LAUNCHER="${toplevel?}/tests/fixtures/bin/rofi" clipmenu --foo bar > "$temp" 
 
 # We have a special case to add -dmenu for rofi
 grep -Fxq 'rofi args: -dmenu -p clipmenu -l 8 --foo bar' "$temp"
+
+# clipmenu should issue a warning message if the user specified an unrecognized
+# CM_LAUNCHER_TYPE value
+unrecognized_launcher_type="foobar-${RANDOM}"
+CM_LAUNCHER="/not/really/a/launcher-${RANDOM}" \
+    CM_LAUNCHER_TYPE="$unrecognized_launcher_type" \
+    clipmenu --foo bar > "$temp" 2>&1 || :
+
+grep -Fxq "Unrecognized CM_LAUNCHER_TYPE '${unrecognized_launcher_type}'; assuming 'dmenu'-type launcher." "$temp"
+
+# clipmenu should *not* issue a warning message if the user specified a
+# CM_LAUNCHER value whose basename is not a recognized CM_LAUNCHER_TYPE value
+CM_LAUNCHER="/not/really/a/launcher-${RANDOM}" \
+    clipmenu --foo bar > "$temp" 2>&1 || :
+
+if grep -xq "Unrecognized CM_LAUNCHER_TYPE '[^']*'; assuming 'dmenu'-type launcher." "$temp"; then
+    exit 1
+fi
+
+# clipmenu should (by default) treat the path to an executable whose basename
+# is `rofi-script` as a dmenu-compatible launcher.
+CM_LAUNCHER="${toplevel?}/tests/fixtures/bin/rofi-script" \
+    clipmenu --foo bar > "$temp" 2>&1 || :
+
+grep -Fxq "rofi-script args: -l 8 --foo bar" "$temp"

--- a/tests/test-clipmenu
+++ b/tests/test-clipmenu
@@ -15,44 +15,6 @@ cleanup_pre() {
     fi
 }
 
-cat - "${toplevel?}/clipmenu" > "${tempdir}/clipmenu" << 'EOF'
-#!/usr/bin/env bash
-
-shopt -s expand_aliases
-
-shim() {
-    printf '%s args:' "$1" >&2
-    printf ' %q' "${@:2}" >&2
-    printf '\n' >&2
-
-    i=0
-
-    while IFS= read -r line; do
-        let i++
-        printf '%s line %d stdin: %s\n' "$1" "$i" "$line" >&2
-    done
-
-    if [[ -v SHIM_STDOUT ]]; then
-        printf '%s\n' "$SHIM_STDOUT"
-    fi
-}
-
-# Cannot be an alias due to expansion order with $CM_LAUNCHER
-dmenu() {
-    SHIM_STDOUT="Selected text. (2 lines)" shim dmenu "$@"
-}
-
-rofi() {
-    SHIM_STDOUT="Selected text. (2 lines)" shim rofi "$@"
-}
-
-alias xsel='shim xsel'
-alias xclip='shim xclip'
-alias clipctl='./clipctl'
-EOF
-
-chmod a+x "${tempdir}/clipmenu"
-
 rm -rf "${dir?}"
 mkdir -p "$dir"
 
@@ -68,7 +30,7 @@ EOF
 
 ### TESTS ###
 
-"${tempdir}/clipmenu" --foo bar > "$temp" 2>&1
+clipmenu --foo bar > "$temp" 2>&1
 
 # Arguments are transparently passed to dmenu
 grep -Fxq 'dmenu args: -l 8 --foo bar' "$temp"
@@ -84,7 +46,7 @@ grep -Fxq 'xsel args: --logfile /dev/null -i --primary' "$temp"
 grep -Fxq 'xsel line 1 stdin: Selected text.' "$temp"
 grep -Fxq "xsel line 2 stdin: Yes, it's selected text." "$temp"
 
-CM_LAUNCHER=rofi "${tempdir}/clipmenu" --foo bar > "$temp" 2>&1
+CM_LAUNCHER=rofi clipmenu --foo bar > "$temp" 2>&1
 
 # We have a special case to add -dmenu for rofi
 grep -Fxq 'rofi args: -l 8 -dmenu -p clipmenu --foo bar' "$temp"

--- a/tests/test-clipmenu
+++ b/tests/test-clipmenu
@@ -70,8 +70,17 @@ if grep -xq "Unrecognized CM_LAUNCHER_TYPE '[^']*'; assuming 'dmenu'-type launch
 fi
 
 # clipmenu should (by default) treat the path to an executable whose basename
-# is `rofi-script` as a dmenu-compatible launcher.
-CM_LAUNCHER="${toplevel?}/tests/fixtures/bin/rofi-script" \
-    clipmenu --foo bar > "$temp" 2>&1 || :
+# is `rofi-script` or `custom` as a dmenu-compatible launcher.
+for launcher in rofi-script custom; do
+    CM_LAUNCHER="${toplevel?}/tests/fixtures/bin/${launcher}" \
+        clipmenu --foo bar > "$temp" 2>&1 || :
 
-grep -Fxq "rofi-script args: -l 8 --foo bar" "$temp"
+    grep -Fxq "${launcher} args: -l 8 --foo bar" "$temp"
+done
+
+# Custom launcher type; `mylauncher` uses `CM_DMENU_ARGS` to execute `dmenu`
+CM_LAUNCHER="${toplevel?}/tests/fixtures/bin/mylauncher" \
+    CM_LAUNCHER_TYPE=custom \
+    clipmenu --foo bar > "$temp" 2>&1
+
+grep -Fxq 'mylauncher args: -l 8 --foo bar' "$temp"

--- a/tests/test-clipmenu
+++ b/tests/test-clipmenu
@@ -7,8 +7,15 @@ set -o pipefail
 # shellcheck disable=SC1091
 source "${BASH_SOURCE[0]%/*}/setup.sh"
 
+temp="${tempdir?}/out"
 
-cat - "${toplevel?}/clipmenu" > /tmp/clipmenu << 'EOF'
+cleanup_pre() {
+    if [[ -n "${temp:-}" ]] && [[ -f "$temp" ]]; then
+        cat "$temp"
+    fi
+}
+
+cat - "${toplevel?}/clipmenu" > "${tempdir}/clipmenu" << 'EOF'
 #!/usr/bin/env bash
 
 shopt -s expand_aliases
@@ -44,7 +51,7 @@ alias xclip='shim xclip'
 alias clipctl='./clipctl'
 EOF
 
-chmod a+x /tmp/clipmenu
+chmod a+x "${tempdir}/clipmenu"
 
 rm -rf "${dir?}"
 mkdir -p "$dir"
@@ -61,11 +68,7 @@ EOF
 
 ### TESTS ###
 
-temp=$(mktemp)
-
-trap 'cat "$temp"' EXIT
-
-/tmp/clipmenu --foo bar > "$temp" 2>&1
+"${tempdir}/clipmenu" --foo bar > "$temp" 2>&1
 
 # Arguments are transparently passed to dmenu
 grep -Fxq 'dmenu args: -l 8 --foo bar' "$temp"
@@ -81,7 +84,7 @@ grep -Fxq 'xsel args: --logfile /dev/null -i --primary' "$temp"
 grep -Fxq 'xsel line 1 stdin: Selected text.' "$temp"
 grep -Fxq "xsel line 2 stdin: Yes, it's selected text." "$temp"
 
-CM_LAUNCHER=rofi /tmp/clipmenu --foo bar > "$temp" 2>&1
+CM_LAUNCHER=rofi "${tempdir}/clipmenu" --foo bar > "$temp" 2>&1
 
 # We have a special case to add -dmenu for rofi
 grep -Fxq 'rofi args: -l 8 -dmenu -p clipmenu --foo bar' "$temp"

--- a/tests/test-clipmenu
+++ b/tests/test-clipmenu
@@ -46,7 +46,7 @@ grep -Fxq 'xsel args: --logfile /dev/null -i --primary' "$temp"
 grep -Fxq 'xsel line 1 stdin: Selected text.' "$temp"
 grep -Fxq "xsel line 2 stdin: Yes, it's selected text." "$temp"
 
-CM_LAUNCHER=rofi clipmenu --foo bar > "$temp" 2>&1
+CM_LAUNCHER="${toplevel?}/tests/fixtures/bin/rofi" clipmenu --foo bar > "$temp" 2>&1
 
 # We have a special case to add -dmenu for rofi
-grep -Fxq 'rofi args: -l 8 -dmenu -p clipmenu --foo bar' "$temp"
+grep -Fxq 'rofi args: -dmenu -p clipmenu -l 8 --foo bar' "$temp"

--- a/tests/test-clipmenu
+++ b/tests/test-clipmenu
@@ -4,17 +4,11 @@ set -x
 set -e
 set -o pipefail
 
-dir=$(./clipctl cache-dir)
-cache_file=$dir/line_cache
+# shellcheck disable=SC1091
+source "${BASH_SOURCE[0]%/*}/setup.sh"
 
-if [[ $0 == /* ]]; then
-    location=${0%/*}
-else
-    location=$PWD/${0#./}
-    location=${location%/*}
-fi
 
-cat - "$location/../clipmenu" > /tmp/clipmenu << 'EOF'
+cat - "${toplevel?}/clipmenu" > /tmp/clipmenu << 'EOF'
 #!/usr/bin/env bash
 
 shopt -s expand_aliases
@@ -52,10 +46,10 @@ EOF
 
 chmod a+x /tmp/clipmenu
 
-rm -rf "$dir"
+rm -rf "${dir?}"
 mkdir -p "$dir"
 
-cat > "$cache_file" << 'EOF'
+cat > "${cache_file?}" << 'EOF'
 1234 Selected text. (2 lines)
 1235 Selected text 2. (2 lines)
 EOF

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -9,11 +9,23 @@ num_files=1500
 
 if ! (( NO_RECREATE )); then
     rm -rf "${dir?}"
+fi
+
+if ! [[ -d "${dir?}" ]]; then
     mkdir -p "$dir"
+fi
 
-    msg "Writing $num_files clipboard files"
+num_need="$num_files"
+for child in "$dir"/*; do
+    if [[ -f "$child" ]] && ! [[ "$child" -ef "${cache_file?}" ]]; then
+        (( num_need-- ))
+    fi
+done
 
-    for (( i = 0; i <= num_files; i++ )); do
+if (( num_need > 0 )); then
+    msg "Writing $num_need clipboard files"
+
+    for (( i = 0; i <= num_need; i++ )); do
         (( i % 100 )) || printf '%s... ' "$i"
 
         line_len=$(( (RANDOM % 10000) + 1 ))

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -4,8 +4,8 @@ msg() {
     printf '>>> %s\n' "$@" >&2
 }
 
-dir=$(clipctl cache-dir)
-cache_file=$dir/line_cache
+# shellcheck disable=SC1091
+source "${BASH_SOURCE[0]%/*}/setup.sh"
 
 log=$(mktemp)
 tim=$(mktemp)
@@ -14,16 +14,9 @@ num_files=1500
 
 trap 'rm -f -- "$log" "$tim" "$clipmenu_shim"' EXIT
 
-if [[ $0 == /* ]]; then
-    location=${0%/*}
-else
-    location=$PWD/${0#./}
-    location=${location%/*}
-fi
-
 msg 'Setting up edited clipmenu'
 
-cat - "$location/../clipmenu" > /tmp/clipmenu << EOF
+cat - "${toplevel?}/clipmenu" > /tmp/clipmenu << EOF
 #!/usr/bin/env bash
 
 exec 3>&2 2> >(tee "$log" |
@@ -39,7 +32,7 @@ EOF
 chmod a+x /tmp/clipmenu
 
 if ! (( NO_RECREATE )); then
-    rm -rf "$dir"
+    rm -rf "${dir?}"
     mkdir -p "$dir"
 
     msg "Writing $num_files clipboard files"
@@ -56,7 +49,7 @@ if ! (( NO_RECREATE )); then
         )
         read -r first_line_raw <<< "$data"
         printf -v first_line '%s (%s lines)\n' "$first_line_raw" "$num_lines"
-        printf '%d %s' "$i" "$first_line" >> "$cache_file"
+        printf '%d %s' "$i" "$first_line" >> "${cache_file?}"
         fn=$dir/$(cksum <<< "$first_line")
         printf '%s' "$data" > "$fn"
     done

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -11,23 +11,6 @@ log="${tempdir?}/log"
 tim="${tempdir}/tim"
 num_files=1500
 
-msg 'Setting up edited clipmenu'
-
-cat - "${toplevel?}/clipmenu" > "${tempdir}/clipmenu" << EOF
-#!/usr/bin/env bash
-
-exec 3>&2 2> >(tee "$log" |
-                 sed -u 's/^.*$/now/' |
-                 date -f - +%s.%N > "$tim")
-set -x
-
-dmenu() { :; }
-xsel() { :; }
-
-EOF
-
-chmod a+x "${tempdir}/clipmenu"
-
 if ! (( NO_RECREATE )); then
     rm -rf "${dir?}"
     mkdir -p "$dir"
@@ -56,9 +39,9 @@ else
     msg 'Not nuking/creating new clipmenu files'
 fi
 
-msg 'Running modified clipmenu'
+msg 'Running clipmenu performance-testing wrapper'
 
-time "${tempdir}/clipmenu"
+time log="$log" tim="$tim" clipmenu-perf
 
 (( TIME_ONLY )) && exit 0
 

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-msg() {
-    printf '>>> %s\n' "$@" >&2
-}
-
 # shellcheck disable=SC1091
 source "${BASH_SOURCE[0]%/*}/setup.sh"
 

--- a/tests/test-perf
+++ b/tests/test-perf
@@ -7,16 +7,13 @@ msg() {
 # shellcheck disable=SC1091
 source "${BASH_SOURCE[0]%/*}/setup.sh"
 
-log=$(mktemp)
-tim=$(mktemp)
-clipmenu_shim=$(mktemp)
+log="${tempdir?}/log"
+tim="${tempdir}/tim"
 num_files=1500
-
-trap 'rm -f -- "$log" "$tim" "$clipmenu_shim"' EXIT
 
 msg 'Setting up edited clipmenu'
 
-cat - "${toplevel?}/clipmenu" > /tmp/clipmenu << EOF
+cat - "${toplevel?}/clipmenu" > "${tempdir}/clipmenu" << EOF
 #!/usr/bin/env bash
 
 exec 3>&2 2> >(tee "$log" |
@@ -29,7 +26,7 @@ xsel() { :; }
 
 EOF
 
-chmod a+x /tmp/clipmenu
+chmod a+x "${tempdir}/clipmenu"
 
 if ! (( NO_RECREATE )); then
     rm -rf "${dir?}"
@@ -61,7 +58,7 @@ fi
 
 msg 'Running modified clipmenu'
 
-time /tmp/clipmenu
+time "${tempdir}/clipmenu"
 
 (( TIME_ONLY )) && exit 0
 


### PR DESCRIPTION
Marked as a draft because it is based upon #202.

This PR updates `clipmenu` so that, when executed in `rofi-script` mode, it uses rofi's script option setting protocol to:

1. Update the `rofi` prompt to `clipmenu: `, and
2. Prevent custom input (that is, input that does not match an available selection) for the reasons explained in [the commit](https://github.com/cdown/clipmenu/commit/d59dcd0bda309e08cac69f86f4034befd8f7c2f6).

Thanks!