### PR TITLE
Recognize any set CM_OUTPUT_CLIP value.

### DIFF
--- a/clipmenu
+++ b/clipmenu
@@ -65,7 +65,7 @@ for selection in clipboard primary; do
     xsel --logfile /dev/null -i --"$selection" < "$file"
 done
 
-if (( CM_OUTPUT_CLIP )); then
+if [[ -v CM_OUTPUT_CLIP ]]; then
     cat "$file"
 fi
 


### PR DESCRIPTION
Instead of requiring CM_OUTPUT_CLIP to be specifically set to a non-zero integer, this allows CM_OUTPUT_CLIP to be set to any value, even an empty string.