### PR TITLE
allow selecting the default launcher at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
+LAUNCHER := demnu
 CFLAGS := -std=gnu11 -O2 -Wall -Wextra -Wshadow -Wpointer-arith \
 	  -Wcast-align -Wmissing-prototypes -Wstrict-overflow -Wformat=2 \
 	  -Wwrite-strings -Warray-bounds -Wstrict-prototypes \
 	  -Wno-maybe-uninitialized \
-	  -Werror $(CFLAGS)
+	  -Werror -DLAUNCHER=\"$(LAUNCHER)\" $(CFLAGS)
 CPPFLAGS += -I/usr/X11R6/include -L/usr/X11R6/lib
 LDLIBS += -lX11 -lXfixes
 PREFIX ?= /usr/local

--- a/src/config.c
+++ b/src/config.c
@@ -10,6 +10,9 @@
 #include "x.h"
 
 #define CLIPMENU_VERSION 7
+#ifndef LAUNCHER
+    #define LAUNCHER "dmenu"
+#endif
 
 /**
  * Determines the runtime directory for storing application data. This is _not_
@@ -276,7 +279,7 @@ int config_setup_internal(FILE *file, struct config *cfg) {
          convert_selections, "clipboard", 0},
         {"ignore_window", "CM_IGNORE_WINDOW", &cfg->ignore_window,
          convert_ignore_window, NULL, 0},
-        {"launcher", "CM_LAUNCHER", &cfg->launcher, convert_launcher, "dmenu",
+        {"launcher", "CM_LAUNCHER", &cfg->launcher, convert_launcher, LAUNCHER,
          0},
         {"launcher_pass_dmenu_args", "CM_LAUNCHER_PASS_DMENU_ARGS",
          &cfg->launcher_pass_dmenu_args, convert_bool, "1", 0},

--- a/src/store.c
+++ b/src/store.c
@@ -356,7 +356,7 @@ size_t first_line(const char *text, char *out) {
     size_t nr_lines = 0;
     const char *cur = text;
 
-    out[0] = '\0';
+    out[0] = '\0'; // cppcheck-suppress [ctuArrayIndex,unmatchedSuppression]
 
     for (; *cur; cur++) {
         nr_lines += (*cur == '\n');


### PR DESCRIPTION
This will make things a bit easier to package on gentoo where we want to add the default launcher as a dependency. Currently, the ebuild simply runs sed over the bash script do accomplish it [^0].

[^0]: https://github.com/gentoo/gentoo/blob/1c154d09185a0b0911e9db506d6f00c7941759d2/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild#L29-L33