### PR TITLE
clipmenud: avoid spawning multiple daemons

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -79,6 +79,7 @@ char *get_cache_dir(struct config *cfg);
 
 DEFINE_GET_PATH_FUNCTION(line_cache)
 DEFINE_GET_PATH_FUNCTION(enabled)
+DEFINE_GET_PATH_FUNCTION(session_lock)
 
 extern const char *prog_name;
 struct config _nonnull_ setup(const char *inner_prog_name);


### PR DESCRIPTION
things can get messy if a running clipmenud is diabled via clipctl and then another clipmenud daemon is started. avoid spawning multiple daemons by using a session lock similar to the old bash script.