### PR TITLE
Misc fixes and improvements

### DIFF
--- a/src/clipmenud.c
+++ b/src/clipmenud.c
@@ -25,7 +25,7 @@ static struct clip_store cs;
 static struct config cfg;
 static Window win;
 
-static volatile sig_atomic_t enabled = 1;
+static int enabled = 1;
 static int sig_fd;
 
 static struct cm_selections sels[CM_SEL_MAX];

--- a/src/clipmenud.c
+++ b/src/clipmenud.c
@@ -380,7 +380,9 @@ static int _noreturn_ run(int evt_base) {
 }
 
 #ifndef UNIT_TEST
-int main(void) {
+int main(int argc, char *argv[]) {
+    (void)argv;
+    die_on(argc != 1, "clipmenud doesn't accept any arguments\n");
     int evt_base;
 
     cfg = setup("clipmenud");

--- a/src/clipmenud.c
+++ b/src/clipmenud.c
@@ -191,8 +191,7 @@ static void maybe_trim(void) {
     uint64_t cur_clips;
     expect(cs_len(&cs, &cur_clips) == 0);
     if ((int)cur_clips > cfg.max_clips_batch) {
-        expect(cs_trim(&cs, CS_ITER_NEWEST_FIRST, (uint64_t)cfg.max_clips) ==
-               0);
+        expect(cs_trim(&cs, CS_ITER_NEWEST_FIRST, (size_t)cfg.max_clips) == 0);
     }
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -74,10 +74,10 @@ int convert_bool(const char *str, void *output) {
     return -EINVAL;
 }
 
-int convert_int(const char *str, void *output) {
+int convert_positive_int(const char *str, void *output) {
     char *end;
     long val = strtol(str, &end, 10);
-    if (*end != '\0' || end == str) {
+    if (*end != '\0' || end == str || val < 0 || val > INT_MAX) {
         return -EINVAL;
     }
     *(int *)output = (int)val;
@@ -264,10 +264,11 @@ static int config_apply_default_values(struct config_entry entries[],
  */
 int config_setup_internal(FILE *file, struct config *cfg) {
     struct config_entry entries[] = {
-        {"max_clips", "CM_MAX_CLIPS", &cfg->max_clips, convert_int, "1000", 0},
+        {"max_clips", "CM_MAX_CLIPS", &cfg->max_clips, convert_positive_int,
+         "1000", 0},
         {"max_clips_batch", "CM_MAX_CLIPS_BATCH", &cfg->max_clips_batch,
-         convert_int, "100", 0},
-        {"oneshot", "CM_ONESHOT", &cfg->oneshot, convert_int, "0", 0},
+         convert_positive_int, "100", 0},
+        {"oneshot", "CM_ONESHOT", &cfg->oneshot, convert_positive_int, "0", 0},
         {"own_clipboard", "CM_OWN_CLIPBOARD", &cfg->own_clipboard, convert_bool,
          "0", 0},
         {"selections", "CM_SELECTIONS", &cfg->selections, convert_selections,

--- a/src/config.h
+++ b/src/config.h
@@ -89,7 +89,7 @@ enum selection_type _nonnull_
 storage_atom_to_selection_type(Atom atom, struct cm_selections *sels);
 
 int convert_bool(const char *str, void *output);
-int convert_int(const char *str, void *output);
+int convert_positive_int(const char *str, void *output);
 int convert_ignore_window(const char *str, void *output);
 int config_setup_internal(FILE *file, struct config *cfg);
 void config_free(struct config *cfg);


### PR DESCRIPTION
#### clipmenud: no need to use volatile sig_atomic_t

since there's no signal handlers involved and signals are
handled with regular code via signalfd.

#### clipmenud: don't silently ignore arguments

otherwise running something like `clipmenud --verbose` gives the
false impression of it "working".

#### config: range check parsed integers

negative values don't make sense for these config vars, so
reject them.

also reject values that are too large and would get truncated.

#### clipmenud: correct cast to size_t
