### PR TITLE
Correct type and fix deletion threshold check

### DIFF
--- a/src/clipmenud.c
+++ b/src/clipmenud.c
@@ -188,7 +188,7 @@ static int handle_selection_notify(const XSelectionEvent *se) {
  * size.
  */
 static void maybe_trim(void) {
-    uint64_t cur_clips;
+    size_t cur_clips;
     expect(cs_len(&cs, &cur_clips) == 0);
     if ((int)cur_clips > cfg.max_clips_batch) {
         expect(cs_trim(&cs, CS_ITER_NEWEST_FIRST, (size_t)cfg.max_clips) == 0);

--- a/src/clipmenud.c
+++ b/src/clipmenud.c
@@ -190,7 +190,7 @@ static int handle_selection_notify(const XSelectionEvent *se) {
 static void maybe_trim(void) {
     size_t cur_clips;
     expect(cs_len(&cs, &cur_clips) == 0);
-    if ((int)cur_clips > cfg.max_clips_batch) {
+    if (cur_clips > (size_t)cfg.max_clips + (size_t)cfg.max_clips_batch) {
         expect(cs_trim(&cs, CS_ITER_NEWEST_FIRST, (size_t)cfg.max_clips) == 0);
     }
 }


### PR DESCRIPTION
The current check doesn't make much sense. With the default values, this check will always be true when there's more than 100 clips but no deletion happens until there's at least 1000 clips.

I'm assuming this was meant to be `max_clips + batch`, which would make it work similarly to the old bash script's `CM_MAX_CLIPS_THRESH`.