### PR TITLE
clipdel: add -F to match literal instead of regex

### DIFF
--- a/src/clipdel.c
+++ b/src/clipdel.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "config.h"
@@ -24,20 +25,31 @@ enum delete_mode {
 struct clipdel_state {
     enum delete_mode mode;
     bool invert_match;
-    regex_t rgx;
+    bool literal_match;
+    union {
+        regex_t rgx;
+        const char *needle;
+    };
 };
 
 /**
  * Callback for cs_remove. In order for the delete to actually happen, we must
  * be running DELETE_REAL.
  */
-static enum cs_remove_action _nonnull_
-remove_if_rgx_match(uint64_t hash _unused_, const char *line, void *private) {
+static enum cs_remove_action _nonnull_ remove_if_match(uint64_t hash _unused_,
+                                                       const char *line,
+                                                       void *private) {
     struct clipdel_state *state = private;
-    int ret = regexec(&state->rgx, line, 0, NULL, 0);
-    expect(ret == 0 || ret == REG_NOMATCH);
+    bool matches;
+    if (state->literal_match) {
+        matches = strstr(line, state->needle) != NULL;
+    } else {
+        int ret = regexec(&state->rgx, line, 0, NULL, 0);
+        expect(ret == 0 || ret == REG_NOMATCH);
+        matches = ret == 0;
+    }
 
-    bool wants_del = state->invert_match ? ret : !ret;
+    bool wants_del = state->invert_match ? !matches : matches;
     if (wants_del) {
         puts(line);
     }
@@ -47,20 +59,24 @@ remove_if_rgx_match(uint64_t hash _unused_, const char *line, void *private) {
 }
 
 int main(int argc, char *argv[]) {
-    const char usage[] = "Usage: clipdel [-d] [-v] regex";
+    const char usage[] = "Usage: clipdel [-d] [-F] [-v] pattern";
 
     _drop_(config_free) struct config cfg = setup("clipdel");
 
     struct clipdel_state state = {
         .mode = DELETE_DRY_RUN,
         .invert_match = false,
+        .literal_match = false,
     };
 
     int opt;
-    while ((opt = getopt(argc, argv, "dv")) != -1) {
+    while ((opt = getopt(argc, argv, "dFv")) != -1) {
         switch (opt) {
             case 'd':
                 state.mode = DELETE_REAL;
+                break;
+            case 'F':
+                state.literal_match = true;
                 break;
             case 'v':
                 state.invert_match = true;
@@ -80,13 +96,18 @@ int main(int argc, char *argv[]) {
     _drop_(cs_destroy) struct clip_store cs;
     expect(cs_init(&cs, snip_fd, content_dir_fd) == 0);
 
-    die_on(regcomp(&state.rgx, argv[optind], REG_EXTENDED | REG_NOSUB),
-           "Could not compile regex\n");
+    if (!state.literal_match) {
+        die_on(regcomp(&state.rgx, argv[optind], REG_EXTENDED | REG_NOSUB),
+               "Could not compile regex\n");
+    } else {
+        state.needle = argv[optind];
+    }
 
-    expect(cs_remove(&cs, CS_ITER_OLDEST_FIRST, remove_if_rgx_match, &state) ==
-           0);
+    expect(cs_remove(&cs, CS_ITER_OLDEST_FIRST, remove_if_match, &state) == 0);
 
-    regfree(&state.rgx);
+    if (!state.literal_match) {
+        regfree(&state.rgx);
+    }
 
     return 0;
 }

--- a/tests/x_integration_tests
+++ b/tests/x_integration_tests
@@ -131,6 +131,14 @@ check_nr_clips 3
 [[ $(clipdel -dv a) == foo ]]
 check_nr_clips 2
 
+# Test literal match
+primary '*foo'
+settle
+check_nr_clips 3
+
+[[ $(clipdel -dF '*') == '*foo' ]]
+check_nr_clips 2
+
 # Check selecting starts serving
 xsel -pc
 


### PR DESCRIPTION
this adds an -F flag similar to grep to allow matching literals instead of a regex.

useful in scripting context where the script has a literal line to match against. using -F avoids having to escape troublesome regex characters.