### PR TITLE
tests: use {UBSAN,ASAN}_OPTIONS to abort on error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ bindir := $(PREFIX)/bin
 systemd_user_dir = $(DESTDIR)$(PREFIX)/lib/systemd/user
 debug_cflags := -D_FORTIFY_SOURCE=2 -fsanitize=leak -fsanitize=address \
 	        -fsanitize=undefined -Og -ggdb -fno-omit-frame-pointer \
-	        -fstack-protector-strong -ftrapv
+	        -fstack-protector-strong
 c_files := $(wildcard src/*.c)
 h_files := $(wildcard src/*.h)
 libs := $(filter $(c_files:.c=.o), $(h_files:.h=.o))

--- a/tests/x_integration_tests
+++ b/tests/x_integration_tests
@@ -18,6 +18,8 @@ export PATH=$PWD:$PATH
 export CM_CONFIG=$(mktemp)
 export CM_DIR=$(mktemp -d)
 export CM_DEBUG=1
+export ASAN_OPTIONS='halt_on_error=1:abort_on_error=1'
+export UBSAN_OPTIONS='halt_on_error=1:abort_on_error=1'
 
 launcher=$(mktemp)
 l_out=$(mktemp)


### PR DESCRIPTION
c20991da3 added `-ftrapv`, presumably to to catch overflows in the CI, but this doesn't really work because UBSan overrides the trap:

	[/tmp]~> cat test.c
	#include <limits.h>
	int main(void)
	{
		int a = 5;
		a += INT_MAX;
		return 0;
	}
	[/tmp]~> gcc -fsanitize=undefined -ftrapv test.c -o test
	[/tmp]~> ./test || echo "FAIL"
	test.c:5:4: runtime error: signed integer overflow: 5 + 2147483647 cannot be represented in type 'int'

`-fsanitize-trap` gives the wanted trapping behavior but it doesn't print any diagnostic message:

	[/tmp]~> gcc -fsanitize=undefined -fsanitize-trap test.c -o test
	[/tmp]~> ./test || echo "FAIL"
	zsh: illegal hardware instruction  ./test
	FAIL

it's best to use `{ASAN,UBSAN}_OPTIONS` env vars to configure it to abort on error. this prints diagnostic and also traps:

	[/tmp]~> gcc -fsanitize=undefined test.c -o test
	[/tmp]~> UBSAN_OPTIONS='abort_on_error=1:halt_on_error=1' ./test || echo "FAIL"
	test.c:5:4: runtime error: signed integer overflow: 5 + 2147483647 cannot be represented in type 'int'
	zsh: IOT instruction  UBSAN_OPTIONS='abort_on_error=1:halt_on_error=1' ./test
	FAIL