### PR TITLE
store: use fixed length hex hashes for dir names

### DIFF
--- a/src/clipserve.c
+++ b/src/clipserve.c
@@ -149,7 +149,7 @@ static void _nonnull_ serve_clipboard(uint64_t hash,
 
                 _drop_(XFree) char *window_title =
                     get_window_title(dpy, req->requestor);
-                dbg("Servicing request to window '%s' (0x%lx) for clip %" PRIu64
+                dbg("Servicing request to window '%s' (0x%lX) for clip " PRI_HASH
                     "\n",
                     strnull(window_title), (unsigned long)req->requestor, hash);
 
@@ -180,10 +180,10 @@ static void _nonnull_ serve_clipboard(uint64_t hash,
             }
             case SelectionClear: {
                 if (--remaining_selections == 0) {
-                    dbg("Finished serving clip %" PRIu64 "\n", hash);
+                    dbg("Finished serving clip " PRI_HASH "\n", hash);
                     running = false;
                 } else {
-                    dbg("%d selections remaining to serve for clip %" PRIu64
+                    dbg("%d selections remaining to serve for clip " PRI_HASH
                         "\n",
                         remaining_selections, hash);
                 }
@@ -204,7 +204,7 @@ int main(int argc, char *argv[]) {
     _drop_(config_free) struct config cfg = setup("clipserve");
 
     uint64_t hash;
-    expect(str_to_uint64(argv[1], &hash) == 0);
+    expect(str_to_hex64(argv[1], &hash) == 0);
 
     _drop_(close) int content_dir_fd = open(get_cache_dir(&cfg), O_RDONLY);
     _drop_(close) int snip_fd =
@@ -216,7 +216,7 @@ int main(int argc, char *argv[]) {
 
     _drop_(cs_content_unmap) struct cs_content content;
     die_on(cs_content_get(&cs, hash, &content) < 0,
-           "Hash %" PRIu64 " inaccessible\n", hash);
+           "Hash " PRI_HASH " inaccessible\n", hash);
 
     serve_clipboard(hash, &content);
 

--- a/src/store.c
+++ b/src/store.c
@@ -408,7 +408,7 @@ static int _must_use_ _nonnull_ cs_content_add(struct clip_store *cs,
     bool dupe = false;
 
     char dir_path[CS_HASH_STR_MAX];
-    snprintf(dir_path, sizeof(dir_path), "%" PRIu64, hash);
+    snprintf(dir_path, sizeof(dir_path), PRI_HASH, hash);
 
     int ret = mkdirat(cs->content_dir_fd, dir_path, 0700);
     if (ret < 0) {
@@ -501,7 +501,7 @@ int cs_content_get(struct clip_store *cs, uint64_t hash,
     memset(content, '\0', sizeof(struct cs_content));
 
     char filename[PATH_MAX];
-    snprintf(filename, sizeof(filename), "%" PRIu64 "/1", hash);
+    snprintf(filename, sizeof(filename), PRI_HASH "/1", hash);
 
     _drop_(close) int fd = openat(cs->content_dir_fd, filename, O_RDONLY);
     if (fd < 0) {
@@ -591,7 +591,7 @@ static int _must_use_ _nonnull_ cs_content_remove(struct clip_store *cs,
                                                   uint64_t hash) {
 
     char hash_dir_name[CS_HASH_STR_MAX];
-    snprintf(hash_dir_name, sizeof(hash_dir_name), "%" PRIu64, hash);
+    snprintf(hash_dir_name, sizeof(hash_dir_name), PRI_HASH, hash);
 
     _drop_(close) int hash_dir_fd =
         openat(cs->content_dir_fd, hash_dir_name, O_RDONLY);

--- a/src/store.h
+++ b/src/store.h
@@ -9,7 +9,8 @@
 
 #define CS_SNIP_SIZE 256         /* The size of each struct cs_snip */
 #define CS_SNIP_ALLOC_BATCH 1024 /* How many snips to allocate when growing */
-#define CS_HASH_STR_MAX 21       /* String length of (1 << 64) - 1) + \0 */
+#define CS_HASH_STR_MAX 17       /* String length of 64bit hex + \0 */
+#define PRI_HASH "%016" PRIX64
 
 /**
  * A single snip within the clip store.

--- a/src/util.h
+++ b/src/util.h
@@ -100,7 +100,7 @@ DEFINE_DROP_FUNC(DIR *, closedir)
 
 int _must_use_ negative_errno(void);
 int _nonnull_ str_to_uint64(const char *input, uint64_t *output);
-void _nonnull_ uint64_to_str(uint64_t input, char *output);
+int _nonnull_ str_to_hex64(const char *input, uint64_t *output);
 bool debug_mode_enabled(void);
 
 #endif


### PR DESCRIPTION
mostly cosmetics. having fixed width dirnames results in a nicer listing of the directory. it also matches usual expectation of hashes being stringified in hex format.

![image](https://github.com/user-attachments/assets/2fbbf5d4-6479-422c-81b7-1d46112077f7)
