### PR TITLE
clipdel: add options to delete number of entries

### DIFF
--- a/man/clipdel.1
+++ b/man/clipdel.1
@@ -17,6 +17,17 @@ Real deletion mode. Matching clipboard entries will be removed.
 .B \-F
 Perform a literal (fixed-string) match instead of interpreting the pattern as a regular expression.
 .TP
+.B \-N
+Interpret PATTERN as the amount of entries to delete starting from the oldest.
+E.g
+.I "\-N 1"
+deletes the oldest entry.
+.TP
+.B \-n
+Same as
+.B \-N
+but starting from newest.
+.TP
 .B \-v
 Invert the matching condition; entries that do not match the given pattern are selected for deletion.
 .TP

--- a/src/clipdel.c
+++ b/src/clipdel.c
@@ -19,13 +19,21 @@ enum delete_mode {
 };
 
 /**
+ * The match type for clipdel operations.
+ */
+enum match_type {
+    MATCH_REGEX,
+    MATCH_LITERAL,
+};
+
+/**
  * Holds the application state for a clipdel operation in preparation for
  * passing it as private data to the cs_remove callback.
  */
 struct clipdel_state {
     enum delete_mode mode;
+    enum match_type type;
     bool invert_match;
-    bool literal_match;
     union {
         regex_t rgx;
         const char *needle;
@@ -40,13 +48,19 @@ static enum cs_remove_action _nonnull_ remove_if_match(uint64_t hash _unused_,
                                                        const char *line,
                                                        void *private) {
     struct clipdel_state *state = private;
+    int ret;
     bool matches;
-    if (state->literal_match) {
-        matches = strstr(line, state->needle) != NULL;
-    } else {
-        int ret = regexec(&state->rgx, line, 0, NULL, 0);
-        expect(ret == 0 || ret == REG_NOMATCH);
-        matches = ret == 0;
+    switch (state->type) {
+        case MATCH_LITERAL:
+            matches = strstr(line, state->needle) != NULL;
+            break;
+        case MATCH_REGEX:
+            ret = regexec(&state->rgx, line, 0, NULL, 0);
+            expect(ret == 0 || ret == REG_NOMATCH);
+            matches = ret == 0;
+            break;
+        default:
+            die("unreachable\n");
     }
 
     bool wants_del = state->invert_match ? !matches : matches;
@@ -63,11 +77,7 @@ int main(int argc, char *argv[]) {
 
     _drop_(config_free) struct config cfg = setup("clipdel");
 
-    struct clipdel_state state = {
-        .mode = DELETE_DRY_RUN,
-        .invert_match = false,
-        .literal_match = false,
-    };
+    struct clipdel_state state = {0};
 
     int opt;
     while ((opt = getopt(argc, argv, "dFvh")) != -1) {
@@ -76,7 +86,7 @@ int main(int argc, char *argv[]) {
                 state.mode = DELETE_REAL;
                 break;
             case 'F':
-                state.literal_match = true;
+                state.type = MATCH_LITERAL;
                 break;
             case 'v':
                 state.invert_match = true;
@@ -99,16 +109,21 @@ int main(int argc, char *argv[]) {
     _drop_(cs_destroy) struct clip_store cs;
     expect(cs_init(&cs, snip_fd, content_dir_fd) == 0);
 
-    if (!state.literal_match) {
-        die_on(regcomp(&state.rgx, argv[optind], REG_EXTENDED | REG_NOSUB),
-               "Could not compile regex\n");
-    } else {
-        state.needle = argv[optind];
+    switch (state.type) {
+        case MATCH_REGEX:
+            die_on(regcomp(&state.rgx, argv[optind], REG_EXTENDED | REG_NOSUB),
+                   "Could not compile regex\n");
+            break;
+        case MATCH_LITERAL:
+            state.needle = argv[optind];
+            break;
+        default:
+            die("unreachable\n");
     }
 
     expect(cs_remove(&cs, CS_ITER_OLDEST_FIRST, remove_if_match, &state) == 0);
 
-    if (!state.literal_match) {
+    if (state.type == MATCH_REGEX) {
         regfree(&state.rgx);
     }
 

--- a/src/clipdel.c
+++ b/src/clipdel.c
@@ -24,6 +24,8 @@ enum delete_mode {
 enum match_type {
     MATCH_REGEX,
     MATCH_LITERAL,
+    MATCH_COUNT_NEWEST,
+    MATCH_COUNT_OLDEST,
 };
 
 /**
@@ -37,6 +39,10 @@ struct clipdel_state {
     union {
         regex_t rgx;
         const char *needle;
+        struct {
+            uint64_t current;
+            uint64_t num_delete;
+        } count;
     };
 };
 
@@ -59,6 +65,15 @@ static enum cs_remove_action _nonnull_ remove_if_match(uint64_t hash _unused_,
             expect(ret == 0 || ret == REG_NOMATCH);
             matches = ret == 0;
             break;
+        case MATCH_COUNT_NEWEST:
+        case MATCH_COUNT_OLDEST:
+            if (state->count.current < state->count.num_delete) {
+                matches = true;
+                ++state->count.current;
+            } else {
+                matches = false;
+            }
+            break;
         default:
             die("unreachable\n");
     }
@@ -73,20 +88,26 @@ static enum cs_remove_action _nonnull_ remove_if_match(uint64_t hash _unused_,
 }
 
 int main(int argc, char *argv[]) {
-    const char usage[] = "Usage: clipdel [-d] [-F] [-v] pattern";
+    const char usage[] = "Usage: clipdel [-d] [-F] [-N] [-n] [-v] pattern";
 
     _drop_(config_free) struct config cfg = setup("clipdel");
 
     struct clipdel_state state = {0};
 
     int opt;
-    while ((opt = getopt(argc, argv, "dFvh")) != -1) {
+    while ((opt = getopt(argc, argv, "dFNnvh")) != -1) {
         switch (opt) {
             case 'd':
                 state.mode = DELETE_REAL;
                 break;
             case 'F':
                 state.type = MATCH_LITERAL;
+                break;
+            case 'N':
+                state.type = MATCH_COUNT_OLDEST;
+                break;
+            case 'n':
+                state.type = MATCH_COUNT_NEWEST;
                 break;
             case 'v':
                 state.invert_match = true;
@@ -109,6 +130,7 @@ int main(int argc, char *argv[]) {
     _drop_(cs_destroy) struct clip_store cs;
     expect(cs_init(&cs, snip_fd, content_dir_fd) == 0);
 
+    enum cs_iter_direction direction = CS_ITER_OLDEST_FIRST;
     switch (state.type) {
         case MATCH_REGEX:
             die_on(regcomp(&state.rgx, argv[optind], REG_EXTENDED | REG_NOSUB),
@@ -117,11 +139,20 @@ int main(int argc, char *argv[]) {
         case MATCH_LITERAL:
             state.needle = argv[optind];
             break;
+        case MATCH_COUNT_NEWEST:
+        case MATCH_COUNT_OLDEST:
+            die_on(str_to_uint64(argv[optind], &state.count.num_delete) < 0,
+                   "Bad argument, expected integer: %s\n", argv[optind]);
+            state.count.current = 0;
+            if (state.type == MATCH_COUNT_NEWEST) {
+                direction = CS_ITER_NEWEST_FIRST;
+            }
+            break;
         default:
             die("unreachable\n");
     }
 
-    expect(cs_remove(&cs, CS_ITER_OLDEST_FIRST, remove_if_match, &state) == 0);
+    expect(cs_remove(&cs, direction, remove_if_match, &state) == 0);
 
     if (state.type == MATCH_REGEX) {
         regfree(&state.rgx);

--- a/tests/x_integration_tests
+++ b/tests/x_integration_tests
@@ -147,6 +147,25 @@ check_nr_clips 3
 [[ $(clipdel -dF '*') == '*foo' ]]
 check_nr_clips 2
 
+# Test -n
+primary latest
+settle
+check_nr_clips 3
+
+# Should delete the newest entry
+[[ $(clipdel -dn 1) == 'latest' ]]
+check_nr_clips 2
+
+# Test -N
+primary wibble
+primary wobble
+settle
+check_nr_clips 4
+
+# Should delete everything other than the oldest 2 entries
+[[ $(clipdel -dvN 2) == $'wibble\nwobble' ]]
+check_nr_clips 2
+
 # Check selecting starts serving
 xsel -pc
 


### PR DESCRIPTION
Adds an `-n` flag which allows deleting certain number of entries from newest (default) or oldest (`-N`).

Allows deleting the current clip with `clipdel -n 1` as requested in https://github.com/cdown/clipmenu/issues/57#issuecomment-366728601 and https://github.com/cdown/clipmenu/issues/98.

Caveat: `-n 1` selects the newest/oldest based on time of entry. But the currently serving clip maybe different if another entry was selected thru `clipmenu`.

Opinion on adding a config option to pull an entry to the top when selecting it to be served via clipmenu? I'd like this personally, since I find it more natural to see the current serving entry on the top when opening clipmenu.