### PR TITLE
config: more friendly error message on mkdir failure

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -44,7 +44,8 @@ char *get_cache_dir(struct config *cfg) {
     // In case config changed, do the write anyway
     snprintf_safe(cache_dir, PATH_MAX, "%s/clipmenu.%d.%ld", cfg->runtime_dir,
                   CLIPMENU_VERSION, (long)getuid());
-    expect(mkdir(cache_dir, S_IRWXU) == 0 || errno == EEXIST);
+    die_on(mkdir(cache_dir, S_IRWXU) != 0 && errno != EEXIST,
+           "Failed to create directory: %s\n", cache_dir);
     return cache_dir;
 }
 


### PR DESCRIPTION
### config: more friendly error message on mkdir failure

mkdir may fail in case user sets cm_dir to something
non-existent expecting clipmenu to create the parent dir as
well. give a nicer error message on such failure.

### ~~config, store: set the sticky bit on directories~~

~~clipmenu uses XDG_RUNTIME_DIR if set, which according to the
spec [^0] is subject to cleanup every 6 hours, unless the sticky
bit is set. we almost certainly do not want this, so set the
sticky bit on the directories we create.~~

[^0]: https://specifications.freedesktop.org/basedir-spec/latest/
