### PR TITLE
clipdel: add -q to suppress output

### DIFF
--- a/man/clipdel.1
+++ b/man/clipdel.1
@@ -31,6 +31,9 @@ but starting from newest.
 .B \-v
 Invert the matching condition; entries that do not match the given pattern are selected for deletion.
 .TP
+.B \-q
+Quiet mode. Do not print matching entries to standard output.
+.TP
 .B \-h, \--help
 Display the help message (invokes the manual page).
 .SH CONFIGURATION

--- a/src/clipdel.c
+++ b/src/clipdel.c
@@ -36,6 +36,7 @@ struct clipdel_state {
     enum delete_mode mode;
     enum match_type type;
     bool invert_match;
+    bool quiet;
     union {
         regex_t rgx;
         const char *needle;
@@ -79,7 +80,7 @@ static enum cs_remove_action _nonnull_ remove_if_match(uint64_t hash _unused_,
     }
 
     bool wants_del = state->invert_match ? !matches : matches;
-    if (wants_del) {
+    if (wants_del && !state->quiet) {
         puts(line);
     }
 
@@ -88,17 +89,20 @@ static enum cs_remove_action _nonnull_ remove_if_match(uint64_t hash _unused_,
 }
 
 int main(int argc, char *argv[]) {
-    const char usage[] = "Usage: clipdel [-d] [-F] [-N] [-n] [-v] pattern";
+    const char usage[] = "Usage: clipdel [-d] [-q] [-F] [-N] [-n] [-v] pattern";
 
     _drop_(config_free) struct config cfg = setup("clipdel");
 
     struct clipdel_state state = {0};
 
     int opt;
-    while ((opt = getopt(argc, argv, "dFNnvh")) != -1) {
+    while ((opt = getopt(argc, argv, "dqFNnvh")) != -1) {
         switch (opt) {
             case 'd':
                 state.mode = DELETE_REAL;
+                break;
+            case 'q':
+                state.quiet = true;
                 break;
             case 'F':
                 state.type = MATCH_LITERAL;

--- a/tests/x_integration_tests
+++ b/tests/x_integration_tests
@@ -169,6 +169,12 @@ check_nr_clips 3
 [[ $(clipdel a) == $'bar\nbaz' ]]
 check_nr_clips 3
 
+# Test -q, should have no output
+[[ -z "$(clipdel -q a)" ]]
+
+# Should have output now
+[[ -n "$(clipdel a)" ]]
+
 # Likewise but inversion
 [[ $(clipdel -v a) == foo ]]
 check_nr_clips 3


### PR DESCRIPTION
While working on an script involving clipmenu I ran into it printing all the pastes to be deleted to stdout. This was a major inconvenience as I was trying to delete sensitive information following a list of regexs.

This PR adds a -q (quiet) flag to allow the output to be suppressed natively without the need for workarounds (as redirecting output to /dev/null).

Changes:
added -q flag to clipdel.c
updated clipdel.1 man page
Added integration tests in tests/x_integration_tests to verify the quiet behavior